### PR TITLE
Remove email address from appointment summaries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ gem 'pg'
 gem 'puma'
 gem 'rails', '4.2.0'
 gem 'rails-i18n', '~> 4.0.0'
-gem 'rfc-822' # email validation
 gem 'sass-rails', '~> 5.0'
 gem 'sidekiq'
 gem 'sinatra', require: nil # Sidekiq UI

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,7 +180,6 @@ GEM
       redis (~> 3.0, >= 3.0.4)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)
-    rfc-822 (0.4.0)
     rspec-core (3.2.2)
       rspec-support (~> 3.2.0)
     rspec-expectations (3.2.0)
@@ -288,7 +287,6 @@ DEPENDENCIES
   rails (= 4.2.0)
   rails-i18n (~> 4.0.0)
   rails_12factor
-  rfc-822
   rspec-rails
   rubocop
   sass-rails (~> 5.0)

--- a/app/controllers/appointment_summaries_controller.rb
+++ b/app/controllers/appointment_summaries_controller.rb
@@ -26,7 +26,7 @@ class AppointmentSummariesController < ApplicationController
   private
 
   def appointment_summary_params
-    params.require(:appointment_summary).permit(:title, :first_name, :last_name, :email_address,
+    params.require(:appointment_summary).permit(:title, :first_name, :last_name,
                                                 :address_line_1, :address_line_2, :address_line_3,
                                                 :town, :county, :postcode, :date_of_appointment,
                                                 :reference_number, :value_of_pension_pots,

--- a/app/models/appointment_summary.rb
+++ b/app/models/appointment_summary.rb
@@ -38,7 +38,6 @@ class AppointmentSummary < ActiveRecord::Base
 
   validates :title, presence: true, inclusion: { in: TITLES }
   validates :last_name, presence: true
-  validates :email_address, format: RFC822::EMAIL, allow_blank: true
   validates :date_of_appointment, timeliness: { on_or_before: -> { Date.current },
                                                 on_or_after: Date.new(2015),
                                                 type: :date }

--- a/app/views/appointment_summaries/new.html.erb
+++ b/app/views/appointment_summaries/new.html.erb
@@ -34,13 +34,6 @@
     <%= f.text_field :last_name, class: %w(form-control input-md-3 t-last-name) %>
   </div>
 
-  <div class="row">
-    <div class="form-group col-xs-6">
-      <%= f.label :email_address %>
-      <%= f.text_field :email_address, class: %w(form-control t-email-address) %>
-    </div>
-  </div>
-
   <h3>Postal address</h3>
 
   <div class="form-group">

--- a/db/migrate/20150319084903_remove_email_address_from_appointment_summaries.rb
+++ b/db/migrate/20150319084903_remove_email_address_from_appointment_summaries.rb
@@ -1,0 +1,5 @@
+class RemoveEmailAddressFromAppointmentSummaries < ActiveRecord::Migration
+  def change
+    remove_column :appointment_summaries, :email_address, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150318151718) do
+ActiveRecord::Schema.define(version: 20150319084903) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,7 +20,6 @@ ActiveRecord::Schema.define(version: 20150318151718) do
     t.string   "name"
     t.datetime "created_at",            null: false
     t.datetime "updated_at",            null: false
-    t.string   "email_address"
     t.date     "date_of_appointment"
     t.string   "value_of_pension_pots"
     t.string   "income_in_retirement"

--- a/features/step_definitions/record_of_guidance_steps.rb
+++ b/features/step_definitions/record_of_guidance_steps.rb
@@ -4,7 +4,6 @@ When(/^appointment details are captured$/) do
   page.title.select 'Mr'
   page.first_name.set 'Joe'
   page.last_name.set 'Bloggs'
-  page.email_address.set 'joe.bloggs@example.com'
   page.address_line_1.set 'HM Treasury'
   page.address_line_2.set '1 Horse Guards Road'
   page.town.set 'London'
@@ -29,7 +28,6 @@ When(/^appointment details are captured$/) do
   expect(appointment_summary.title).to eql('Mr')
   expect(appointment_summary.first_name).to eql('Joe')
   expect(appointment_summary.last_name).to eql('Bloggs')
-  expect(appointment_summary.email_address).to eql('joe.bloggs@example.com')
   expect(appointment_summary.address_line_1).to eql('HM Treasury')
   expect(appointment_summary.address_line_2).to eql('1 Horse Guards Road')
   expect(appointment_summary.town).to eql('London')

--- a/features/support/pages/appointment_summary_page.rb
+++ b/features/support/pages/appointment_summary_page.rb
@@ -4,7 +4,6 @@ class AppointmentSummaryPage < SitePrism::Page
   element :title, '.t-title'
   element :first_name, '.t-first-name'
   element :last_name, '.t-last-name'
-  element :email_address, '.t-email-address'
   element :address_line_1, '.t-address-line-1'
   element :address_line_2, '.t-address-line-2'
   element :address_line_3, '.t-address-line-3'

--- a/spec/models/appointment_summary_spec.rb
+++ b/spec/models/appointment_summary_spec.rb
@@ -12,9 +12,6 @@ RSpec.describe AppointmentSummary, type: :model do
   it { is_expected.to allow_value('Mr').for(:title) }
   it { is_expected.to_not allow_value('Alien').for(:title) }
 
-  it { is_expected.to allow_value('joe.bloggs@example.com').for(:email_address) }
-  it { is_expected.to_not allow_value('joe @ example.com').for(:email_address) }
-
   it { is_expected.to allow_value('2015-02-10').for(:date_of_appointment) }
   it { is_expected.to allow_value('12/02/2015').for(:date_of_appointment) }
   it { is_expected.to_not allow_value('10/02/2012').for(:date_of_appointment) }


### PR DESCRIPTION
This is no longer needed as all output will be issued as white mail.