### PR TITLE
Only apply certain validation for eligible appointment attendees

### DIFF
--- a/app/models/appointment_summary.rb
+++ b/app/models/appointment_summary.rb
@@ -42,9 +42,13 @@ class AppointmentSummary < ActiveRecord::Base
                                                 on_or_after: Date.new(2015),
                                                 type: :date }
   validates :reference_number, numericality: true, presence: true
-  validates :value_of_pension_pots, numericality: true, allow_blank: true
-  validates :upper_value_of_pension_pots, numericality: true, allow_blank: true
-  validates :income_in_retirement, inclusion: { in: %w(pension other) }
+
+  with_options numericality: true, allow_blank: true, if: :eligible_for_guidance? do |eligible|
+    eligible.validates :value_of_pension_pots
+    eligible.validates :upper_value_of_pension_pots
+  end
+
+  validates :income_in_retirement, inclusion: { in: %w(pension other) }, if: :eligible_for_guidance?
   validates :guider_name, presence: true
   validates :guider_organisation, inclusion: { in: %w(tpas dwp) }
 

--- a/spec/models/appointment_summary_spec.rb
+++ b/spec/models/appointment_summary_spec.rb
@@ -1,16 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe AppointmentSummary, type: :model do
-  let(:continue_working) { false }
-  let(:has_defined_contribution_pension) { 'no' }
-  let(:params) do
-    {
-      has_defined_contribution_pension: has_defined_contribution_pension,
-      continue_working: continue_working
-    }
+  subject do
+    described_class.new(continue_working: continue_working,
+                        has_defined_contribution_pension: has_defined_contribution_pension)
   end
 
-  subject { described_class.new(params) }
+  let(:continue_working) { false }
+  let(:has_defined_contribution_pension) { 'yes' }
 
   it { is_expected.to belong_to(:user) }
 
@@ -66,9 +63,21 @@ RSpec.describe AppointmentSummary, type: :model do
   end
 
   context 'when ineligible for guidance' do
+    let(:has_defined_contribution_pension) { 'no' }
+
     it { is_expected.to_not be_eligible_for_guidance }
     it { is_expected.to_not be_generic_guidance }
     it { is_expected.to_not be_custom_guidance }
+
+    it { is_expected.to_not validate_presence_of(:value_of_pension_pots) }
+    it { is_expected.to_not validate_presence_of(:upper_value_of_pension_pots) }
+
+    it { is_expected.to_not validate_numericality_of(:value_of_pension_pots) }
+    it { is_expected.to_not validate_numericality_of(:upper_value_of_pension_pots) }
+
+    it do
+      is_expected.to_not validate_inclusion_of(:income_in_retirement).in_array(%w(pension other))
+    end
   end
 
   context 'when eligible for guidance' do


### PR DESCRIPTION
If the attendee does not have a DC pension we don't need to know about their pot size or source of income.

cc/ @aduggin 