### PR TITLE
Add placeholder for CSV representation of output docs

### DIFF
--- a/app/domain/output_document.rb
+++ b/app/domain/output_document.rb
@@ -11,6 +11,10 @@ class OutputDocument
     ERB.new(template).result(binding)
   end
 
+  def csv
+    'c,s,v'
+  end
+
   private
 
   def template

--- a/spec/domain/output_document_spec.rb
+++ b/spec/domain/output_document_spec.rb
@@ -111,4 +111,10 @@ RSpec.describe OutputDocument do
       end
     end
   end
+
+  describe '#csv' do
+    subject { described_class.new(appointment_summary).csv }
+
+    it { is_expected.to_not be_empty }
+  end
 end


### PR DESCRIPTION
This interface ties together the card dealing with batch processing and the one concerning the CSV generation itself