### PR TITLE
Align `OutputDocument` fields with data dictionary

### DIFF
--- a/app/domain/output_document.rb
+++ b/app/domain/output_document.rb
@@ -66,6 +66,10 @@ class OutputDocument
     "#{appointment_summary.id}/#{appointment_summary.reference_number}"
   end
 
+  def format
+    appointment_summary.format_preference
+  end
+
   def pages_to_render
     case variant
     when 'tailored'

--- a/app/domain/output_document.rb
+++ b/app/domain/output_document.rb
@@ -115,8 +115,7 @@ class OutputDocument
   end
 
   def template_for(section)
-    File.read(
-      Rails.root.join('app', 'templates', "output_document_#{section}.html.erb"))
+    File.read(Rails.root.join('app', 'templates', "output_document_#{section}.html.erb"))
   end
 
   def to_currency(number)

--- a/app/domain/output_document.rb
+++ b/app/domain/output_document.rb
@@ -3,7 +3,7 @@ class OutputDocument
 
   attr_accessor :appointment_summary
 
-  delegate :id, :guider_name, :income_in_retirement, :continue_working, :unsure,
+  delegate :id, :income_in_retirement, :continue_working, :unsure,
            :leave_inheritance, :wants_flexibility, :wants_security,
            :wants_lump_sum, :poor_health,
            to: :appointment_summary
@@ -58,7 +58,7 @@ class OutputDocument
   end
 
   def lead
-    "You recently had a Pension Wise guidance appointment with #{guider_name} " \
+    "You recently had a Pension Wise guidance appointment with #{guider_first_name} " \
       "from #{guider_organisation} on #{appointment_date}."
   end
 
@@ -68,6 +68,10 @@ class OutputDocument
 
   def format
     appointment_summary.format_preference
+  end
+
+  def guider_first_name
+    appointment_summary.guider_name
   end
 
   def pages_to_render

--- a/app/templates/output_document_introduction.html.erb
+++ b/app/templates/output_document_introduction.html.erb
@@ -9,7 +9,7 @@
 
       <p class="appointment-details__label">Your guidance specialist was</p>
 
-      <p class="appointment-details__data"><%= guider_name %></p>
+      <p class="appointment-details__data"><%= guider_first_name %></p>
 
       <p class="appointment-details__label">from</p>
 


### PR DESCRIPTION
Per my comment on the doc, the data dictionary mentions `guider_first_name` but I believe the printhouse are expecting `guider_name` which we already have @andrewgarner ?