### PR TITLE
Exclude braille and large text from batches

### DIFF
--- a/app/services/create_batch.rb
+++ b/app/services/create_batch.rb
@@ -1,6 +1,6 @@
 class CreateBatch
   def call
-    unprocessed_appointment_summaries = AppointmentSummary.unprocessed
+    unprocessed_appointment_summaries = AppointmentSummary.unprocessed.where(format_preference: :standard)
 
     return nil if unprocessed_appointment_summaries.empty?
 

--- a/features/accessibility.feature
+++ b/features/accessibility.feature
@@ -9,7 +9,14 @@ Scenario Outline: Document formats
   Then it should be in <format> format
 
   Examples:
+  | format   |
+  | standard |
+
+Scenario Outline: Unsupported document formats
+  When the customer prefers to receive documentation in <format> format
+  Then we should not send them any documentation, for now
+
+  Examples:
   | format     |
-  | standard   |
   | large text |
   | braille    |

--- a/features/step_definitions/accessibility_steps.rb
+++ b/features/step_definitions/accessibility_steps.rb
@@ -11,3 +11,9 @@ end
 Then(/^it should be in (.*?) format$/) do |format_preference|
   expect_uploaded_csv_to_include(format: format_preference.gsub(/\s+/, '_'))
 end
+
+Then(/^we should not send them any documentation, for now$/) do
+  step('we send them their record of guidance')
+
+  expect(read_uploaded_csv).to be_empty
+end

--- a/features/support/matchers/expect_uploaded_csv_to_include.rb
+++ b/features/support/matchers/expect_uploaded_csv_to_include.rb
@@ -11,7 +11,7 @@ end
 module UploadedCSVMatcher
   def read_uploaded_csv
     path = FakeSFTP.find_path('*.csv')
-    contents = FakeSFTP.read(path)
+    contents = path ? FakeSFTP.read(path) : ''
 
     CSV.parse(contents, headers: true, converters: [:numeric, :date_time, :boolean],
                         header_converters: :symbol, col_sep: '|')

--- a/spec/services/create_batch_spec.rb
+++ b/spec/services/create_batch_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe CreateBatch, '#call' do
       title: 'Mr', last_name: 'Bloggs', date_of_appointment: Time.zone.today,
       reference_number: '123', guider_name: 'Jimmy', guider_organisation: 'tpas',
       address_line_1: '29 Acacia Road', town: 'Beanotown', postcode: 'BT7 3AP',
-      has_defined_contribution_pension: 'yes', income_in_retirement: 'pension')
+      has_defined_contribution_pension: 'yes', income_in_retirement: 'pension',
+      format_preference: 'standard')
   end
 
   context 'with no items to be processed' do
@@ -17,15 +18,36 @@ RSpec.describe CreateBatch, '#call' do
   end
 
   context 'with items to be processed' do
-    let(:appointment_summaries) { 2.times.map { create_appointment_summary } }
-
-    before do
-      allow(AppointmentSummary)
-        .to receive(:unprocessed)
-        .and_return(appointment_summaries)
-    end
+    let!(:appointment_summaries) { 2.times.map { create_appointment_summary } }
 
     it { is_expected.to be_a(Batch) }
     specify { expect(batch.appointment_summaries).to eq(appointment_summaries) }
+
+    context 'where some have currently unsupported formats' do
+      let(:braille_summaries) do
+        2.times.map do
+          create_appointment_summary.tap { |as| as.update_attributes!(format_preference: 'braille') }
+        end
+      end
+
+      let(:large_text_summaries) do
+        2.times.map do
+          create_appointment_summary.tap { |as| as.update_attributes!(format_preference: 'large_text') }
+        end
+      end
+
+      before do
+        appointment_summaries.concat(braille_summaries)
+        appointment_summaries.concat(large_text_summaries)
+      end
+
+      it 'should ignore braille appointment_summaries' do
+        expect(batch.appointment_summaries).not_to include(*braille_summaries)
+      end
+
+      it 'should ignore large_text appointment_summaries' do
+        expect(batch.appointment_summaries).not_to include(*large_text_summaries)
+      end
+    end
   end
 end


### PR DESCRIPTION
The print house can't currently deal with braille or large text, so we
should not send output documents in those formats to them