### PR TITLE
Add logging to output document processing

### DIFF
--- a/app/services/create_batch.rb
+++ b/app/services/create_batch.rb
@@ -1,6 +1,24 @@
 class CreateBatch
+  def initialize(logger = Rails.logger)
+    @logger = logger
+  end
+
   def call
+    logger.debug('CreateBatch started')
+
+    create_batch
+  ensure
+    logger.debug('CreatBatch completed')
+  end
+
+  private
+
+  attr_reader :logger
+
+  def create_batch
     unprocessed_appointment_summaries = AppointmentSummary.unprocessed.where(format_preference: :standard)
+
+    logger.info("Unprocessed appointment summaries: #{unprocessed_appointment_summaries.count}")
 
     return nil if unprocessed_appointment_summaries.empty?
 

--- a/app/services/process_output_documents.rb
+++ b/app/services/process_output_documents.rb
@@ -1,15 +1,58 @@
 class ProcessOutputDocuments
+  def initialize(logger = Rails.logger)
+    @logger = logger
+  end
+
   def call
-    batch = CreateBatch.new.call
+    run_id = SecureRandom.uuid
+    logger.tagged('ProcessOutputDocuments', run_id) do |logger|
+      Runner.new(logger).call
+    end
+  end
 
-    return nil unless batch
+  private
 
-    output_documents = batch.appointment_summaries.map do |appointment_summary|
-      OutputDocument.new(appointment_summary)
+  attr_reader :logger
+
+  class Runner
+    attr_reader :logger
+
+    def initialize(logger)
+      @logger = logger
     end
 
-    csv = CSVRenderer.new(output_documents).render
+    def call
+      logger.info('Started ProcessOutputDocuments')
 
-    UploadToPrintHouse.new(csv).call
+      process_output_documents
+    rescue => error
+      log_error(error)
+      raise
+    ensure
+      success_or_failure = error ? 'failure' : 'success'
+      logger.info("Completed ProcessOutputDocuments (#{success_or_failure})")
+    end
+
+    private
+
+    def process_output_documents
+      batch = CreateBatch.new(logger).call
+
+      return nil unless batch
+
+      output_documents = batch.appointment_summaries.map do |appointment_summary|
+        OutputDocument.new(appointment_summary)
+      end
+
+      csv = CSVRenderer.new(output_documents).render
+
+      UploadToPrintHouse.new(csv, logger).call
+    end
+
+    def log_error(error)
+      logger.error("#{error.backtrace.first}: #{error.message} (#{error.class})")
+      error.backtrace.drop(1).map { |s| "\t#{s}" }
+        .each { |e| logger.error(e) }
+    end
   end
 end

--- a/app/services/upload_to_print_house.rb
+++ b/app/services/upload_to_print_house.rb
@@ -4,8 +4,9 @@ require 'stringio'
 class UploadToPrintHouse
   attr_accessor :csv
 
-  def initialize(csv)
+  def initialize(csv, logger = Rails.logger)
     @csv = csv
+    @logger = logger
   end
 
   def call
@@ -15,10 +16,15 @@ class UploadToPrintHouse
 
   private
 
+  attr_reader :logger
+
   def upload_file(path, contents)
     io = StringIO.new(contents)
     Net::SFTP.start(host, user, password: password) do |sftp|
+      logger.info("Connected to #{host}")
+
       sftp.upload!(io, path)
+      logger.info("#{path} uploaded")
     end
   end
 

--- a/app/services/upload_to_print_house.rb
+++ b/app/services/upload_to_print_house.rb
@@ -17,8 +17,20 @@ class UploadToPrintHouse
 
   def upload_file(path, contents)
     io = StringIO.new(contents)
-    Net::SFTP.start(ENV['SFTP_HOST'], ENV['SFTP_USER'], password: ENV['SFTP_PASSWORD']) do |sftp|
+    Net::SFTP.start(host, user, password: password) do |sftp|
       sftp.upload!(io, path)
     end
+  end
+
+  def host
+    ENV['SFTP_HOST']
+  end
+
+  def user
+    ENV['SFTP_USER']
+  end
+
+  def password
+    ENV['SFTP_PASSWORD']
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,4 +41,6 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   config.active_job.queue_adapter = :test
+
+  config.log_level = :info
 end

--- a/features/support/fake_sftp.rb
+++ b/features/support/fake_sftp.rb
@@ -23,6 +23,7 @@ module FakeSFTP
   end
 end
 
+ENV['SFTP_HOST'] = 'Fake-SFTP-Host'
 allow(Net::SFTP).to receive(:start).and_yield(FakeSFTP)
 
 Before { FakeSFTP.clear_uploaded }

--- a/spec/services/process_output_documents_spec.rb
+++ b/spec/services/process_output_documents_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe ProcessOutputDocuments, '#call' do
       allow(CSVRenderer).to receive(:new)
         .with([output_document]).and_return(csv_renderer)
       allow(UploadToPrintHouse).to receive(:new)
-        .with(csv).and_return(print_house)
+        .with(csv, kind_of(ActiveSupport::Logger)).and_return(print_house)
     end
 
     it { is_expected.to eq(result) }


### PR DESCRIPTION
This adds logging to the output document processing without refactoring or rewriting how the processing itself works.

I'm not super happy with it, but it is the least amount of change to get logging in. I think this area needs attention, after which the logging will (along with everything else) hopefully end up cleaner.