### PR TITLE
Do not process non-uk appointment summaries

### DIFF
--- a/app/services/create_batch.rb
+++ b/app/services/create_batch.rb
@@ -1,6 +1,8 @@
 class CreateBatch
   def call
-    unprocessed_appointment_summaries = AppointmentSummary.unprocessed.where(format_preference: :standard)
+    unprocessed_appointment_summaries = AppointmentSummary.unprocessed
+                                        .where(format_preference: :standard)
+                                        .where(country: Countries.uk)
 
     return nil if unprocessed_appointment_summaries.empty?
 


### PR DESCRIPTION
Includes chained `where` statements on top of a scope, which will be resolved in an upcoming PR.