### PR TITLE
Self service password reset

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ActiveRecord::Base
   devise :database_authenticatable, :confirmable, :invitable, :lockable, :timeoutable, :trackable,
-         :validatable, :zxcvbnable
+         :validatable, :zxcvbnable, :recoverable
 
   has_many :appointment_summaries
 

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,0 +1,28 @@
+<div class="page-header">
+  <h2>Change your password</h2>
+</div>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+  <%= error_messages_for(resource) %>
+  <%= f.hidden_field :reset_password_token %>
+
+  <div class="row">
+    <div class="form-group col-xs-4">
+      <%= f.label :password, 'New password' %>
+      <%= f.password_field :password, autofocus: true, autocomplete: 'off', class: %w(form-control) %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="form-group col-xs-4">
+      <%= f.label :password_confirmation, 'Confirm new password' %>
+      <%= f.password_field :password_confirmation, autocomplete: 'off', class: %w(form-control) %>
+    </div>
+  </div>
+
+  <p>
+    <%= f.submit 'Change my password', class: %w(btn btn-success) %>
+  </p>
+<% end %>
+
+<%= render 'devise/shared/links' %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,0 +1,20 @@
+<div class="page-header">
+  <h2>Forgot your password?</h2>
+</div>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+  <%= error_messages_for(resource) %>
+
+  <div class="row">
+    <div class="form-group col-xs-4">
+      <%= f.label :email %>
+      <%= f.email_field :email, autofocus: true, class: %w(form-control) %>
+    </div>
+  </div>
+
+  <p>
+    <%= f.submit 'Send me reset password instructions', class: %w(btn btn-success) %>
+  </p>
+<% end %>
+
+<%= render "devise/shared/links" %>


### PR DESCRIPTION
It adds this link to the login page:

![log in 2015-04-27 11-11-40](https://cloud.githubusercontent.com/assets/45121/7345646/ae0eb9ce-ecce-11e4-99eb-cf7a3833cad2.png)

Which leads on to:

![gov uk 2015-04-27 11-12-06](https://cloud.githubusercontent.com/assets/45121/7345644/ae0c7a88-ecce-11e4-921f-f1c7668fce20.png)

And finally:

![gov uk 2015-04-27 11-12-40](https://cloud.githubusercontent.com/assets/45121/7345645/ae0d30ae-ecce-11e4-8987-b64ac8236c54.png)

The forms for these last 2 pages are the ones that ship with Devise. Do we care enough to rewrite them to be congruent with our styleguide? If so, do we want to rework the login form?

Also, are we ok with deploying the code change along with the database change or do we want to split this up into 2 deployments?

