### PR TITLE
Upload all unprocessed batches

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'sass-rails', '~> 5.0'
 gem 'sidekiq'
 gem 'sinatra', require: nil # Sidekiq UI
 gem 'uglifier', '>= 1.3.0'
+gem 'wisper'
 
 group :development, :test do
   gem 'launchy'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,6 +278,7 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    wisper (1.6.0)
     xpath (2.0.0)
       nokogiri (~> 1.3)
     zxcvbn-ruby (0.0.3)
@@ -321,3 +322,4 @@ DEPENDENCIES
   spring-commands-rspec
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+  wisper

--- a/app/models/appointment_summary.rb
+++ b/app/models/appointment_summary.rb
@@ -2,7 +2,7 @@ require 'json'
 require 'uri'
 
 class AppointmentSummary < ActiveRecord::Base
-  scope :unprocessed, lambda {
+  scope :unbatched, lambda {
     includes(:appointment_summaries_batches)
       .where(appointment_summaries_batches: { appointment_summary_id: nil })
   }

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -1,4 +1,6 @@
 class Batch < ActiveRecord::Base
+  scope :unprocessed, -> { where(uploaded_at: nil) }
+
   has_many :appointment_summaries_batches, dependent: :destroy
   has_many :appointment_summaries, through: :appointment_summaries_batches
 

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -1,4 +1,8 @@
 class Batch < ActiveRecord::Base
   has_many :appointment_summaries_batches, dependent: :destroy
   has_many :appointment_summaries, through: :appointment_summaries_batches
+
+  def mark_as_uploaded
+    update(uploaded_at: Time.zone.now)
+  end
 end

--- a/app/services/create_batch.rb
+++ b/app/services/create_batch.rb
@@ -1,11 +1,11 @@
 class CreateBatch
   def call
-    unprocessed_appointment_summaries = AppointmentSummary.unprocessed
-                                        .where(format_preference: :standard)
-                                        .where(country: Countries.uk)
+    unbatched_appointment_summaries = AppointmentSummary.unbatched
+                                      .where(format_preference: :standard)
+                                      .where(country: Countries.uk)
 
-    return nil if unprocessed_appointment_summaries.empty?
+    return nil if unbatched_appointment_summaries.empty?
 
-    Batch.create(appointment_summaries: unprocessed_appointment_summaries)
+    Batch.create(appointment_summaries: unbatched_appointment_summaries)
   end
 end

--- a/app/services/print_house_sftp_uploader.rb
+++ b/app/services/print_house_sftp_uploader.rb
@@ -2,14 +2,21 @@ require 'net/sftp'
 require 'stringio'
 
 class PrintHouseSFTPUploader
+  include Wisper::Publisher
+
   def call(jobs)
-    Array(jobs).each do |job|
-      upload_file(job.payload_path, job.payload)
-      upload_file(job.trigger_path, job.trigger)
-    end
+    Array(jobs).each { |job| process(job) }
   end
 
   private
+
+  def process(job)
+    upload_file(job.payload_path, job.payload)
+    upload_file(job.trigger_path, job.trigger)
+    broadcast(:upload_succeeded, job)
+  rescue => error
+    broadcast(:upload_failed, job, error)
+  end
 
   def upload_file(path, contents)
     io = StringIO.new(contents)

--- a/app/services/print_house_sftp_uploader.rb
+++ b/app/services/print_house_sftp_uploader.rb
@@ -2,9 +2,11 @@ require 'net/sftp'
 require 'stringio'
 
 class PrintHouseSFTPUploader
-  def call(job)
-    upload_file(job.payload_path, job.payload)
-    upload_file(job.trigger_path, job.trigger)
+  def call(jobs)
+    Array(jobs).each do |job|
+      upload_file(job.payload_path, job.payload)
+      upload_file(job.trigger_path, job.trigger)
+    end
   end
 
   private

--- a/app/services/print_house_sftp_uploader.rb
+++ b/app/services/print_house_sftp_uploader.rb
@@ -2,13 +2,7 @@ require 'net/sftp'
 require 'stringio'
 
 class PrintHouseSFTPUploader
-  attr_accessor :job
-
-  def initialize(job)
-    @job = job
-  end
-
-  def call
+  def call(job)
     upload_file(job.payload_path, job.payload)
     upload_file(job.trigger_path, job.trigger)
   end

--- a/app/services/print_house_sftp_uploader.rb
+++ b/app/services/print_house_sftp_uploader.rb
@@ -1,7 +1,7 @@
 require 'net/sftp'
 require 'stringio'
 
-class UploadToPrintHouse
+class PrintHouseSFTPUploader
   attr_accessor :job
 
   def initialize(job)

--- a/app/services/process_output_documents.rb
+++ b/app/services/process_output_documents.rb
@@ -1,10 +1,6 @@
 class ProcessOutputDocuments
   def call
     CreateBatch.new.call
-    batches = Array(Batch.unprocessed)
-
-    return nil if batches.empty?
-
-    UploadToPrintHouse.new.call(batches)
+    UploadToPrintHouse.new.call(Batch.unprocessed)
   end
 end

--- a/app/services/process_output_documents.rb
+++ b/app/services/process_output_documents.rb
@@ -4,8 +4,6 @@ class ProcessOutputDocuments
 
     return nil unless batch
 
-    csv_upload_job = CSVUploadJob.new(batch)
-
-    PrintHouseSFTPUploader.new.call(csv_upload_job)
+    UploadToPrintHouse.new.call(batch)
   end
 end

--- a/app/services/process_output_documents.rb
+++ b/app/services/process_output_documents.rb
@@ -1,9 +1,10 @@
 class ProcessOutputDocuments
   def call
-    batch = CreateBatch.new.call
+    CreateBatch.new.call
+    batches = Array(Batch.unprocessed)
 
-    return nil unless batch
+    return nil if batches.empty?
 
-    UploadToPrintHouse.new.call(batch)
+    UploadToPrintHouse.new.call(batches)
   end
 end

--- a/app/services/process_output_documents.rb
+++ b/app/services/process_output_documents.rb
@@ -6,6 +6,6 @@ class ProcessOutputDocuments
 
     csv_upload_job = CSVUploadJob.new(batch)
 
-    UploadToPrintHouse.new(csv_upload_job).call
+    PrintHouseSFTPUploader.new(csv_upload_job).call
   end
 end

--- a/app/services/process_output_documents.rb
+++ b/app/services/process_output_documents.rb
@@ -6,6 +6,6 @@ class ProcessOutputDocuments
 
     csv_upload_job = CSVUploadJob.new(batch)
 
-    PrintHouseSFTPUploader.new(csv_upload_job).call
+    PrintHouseSFTPUploader.new.call(csv_upload_job)
   end
 end

--- a/app/services/upload_to_print_house.rb
+++ b/app/services/upload_to_print_house.rb
@@ -1,6 +1,20 @@
 class UploadToPrintHouse
+  attr_reader :uploader
+
+  def initialize
+    @uploader = PrintHouseSFTPUploader.new
+    @uploader.on(:upload_success, &method(:on_upload_success))
+  end
+
   def call(batches)
     jobs = Array(batches).map { |batch| CSVUploadJob.new(batch) }
-    PrintHouseSFTPUploader.new.call(jobs)
+    uploader.call(jobs)
+  end
+
+  private
+
+  def on_upload_success(job)
+    batch = job.batch
+    batch.mark_as_uploaded if batch
   end
 end

--- a/app/services/upload_to_print_house.rb
+++ b/app/services/upload_to_print_house.rb
@@ -1,0 +1,6 @@
+class UploadToPrintHouse
+  def call(batches)
+    jobs = Array(batches).map { |batch| CSVUploadJob.new(batch) }
+    PrintHouseSFTPUploader.new.call(jobs)
+  end
+end

--- a/app/services/upload_to_print_house.rb
+++ b/app/services/upload_to_print_house.rb
@@ -7,11 +7,15 @@ class UploadToPrintHouse
   end
 
   def call(batches)
-    jobs = Array(batches).map { |batch| CSVUploadJob.new(batch) }
-    uploader.call(jobs)
+    jobs = create_upload_jobs(batches)
+    uploader.call(jobs) unless jobs.empty?
   end
 
   private
+
+  def create_upload_jobs(batches)
+    Array(batches).map { |batch| CSVUploadJob.new(batch) }
+  end
 
   def on_upload_success(job)
     batch = job.batch

--- a/db/migrate/20150427131314_remove_processed_at_from_batches.rb
+++ b/db/migrate/20150427131314_remove_processed_at_from_batches.rb
@@ -1,0 +1,5 @@
+class RemoveProcessedAtFromBatches < ActiveRecord::Migration
+  def change
+    remove_column :batches, :processed_at
+  end
+end

--- a/db/migrate/20150427131639_add_uploaded_at_to_batches.rb
+++ b/db/migrate/20150427131639_add_uploaded_at_to_batches.rb
@@ -1,0 +1,5 @@
+class AddUploadedAtToBatches < ActiveRecord::Migration
+  def change
+    add_column :batches, :uploaded_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150427100026) do
+ActiveRecord::Schema.define(version: 20150427131639) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,9 +60,9 @@ ActiveRecord::Schema.define(version: 20150427100026) do
   add_index "appointment_summaries_batches", ["batch_id"], name: "index_appointment_summaries_batches_on_batch_id", using: :btree
 
   create_table "batches", force: :cascade do |t|
-    t.datetime "processed_at"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+    t.datetime "uploaded_at"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/models/appointment_summary_spec.rb
+++ b/spec/models/appointment_summary_spec.rb
@@ -133,8 +133,8 @@ RSpec.describe AppointmentSummary, type: :model do
     end
   end
 
-  describe '.unprocessed' do
-    subject { described_class.unprocessed }
+  describe '.unbatched' do
+    subject { described_class.unbatched }
 
     def create_appointment_summary
       AppointmentSummary.create(
@@ -144,20 +144,20 @@ RSpec.describe AppointmentSummary, type: :model do
         has_defined_contribution_pension: 'yes', income_in_retirement: 'pension')
     end
 
-    context 'with no unprocessed items' do
+    context 'with no unbatched items' do
       let!(:appointment_summaries) { 2.times.map { create_appointment_summary } }
       let!(:previous_batch) { Batch.create(appointment_summaries: appointment_summaries) }
 
       it { is_expected.to be_empty }
     end
 
-    context 'with unprocessed items' do
+    context 'with unbatched items' do
       let!(:appointment_summaries) { 2.times.map { create_appointment_summary } }
 
       it { is_expected.to eq(appointment_summaries) }
     end
 
-    context 'with processed and unprocessed items' do
+    context 'with batched and unbatched items' do
       let!(:appointment_summaries) { 4.times.map { create_appointment_summary } }
       let!(:previous_batch) { Batch.create(appointment_summaries: appointment_summaries[0..1]) }
 

--- a/spec/models/batch_spec.rb
+++ b/spec/models/batch_spec.rb
@@ -3,4 +3,8 @@ require 'rails_helper'
 RSpec.describe Batch, type: :model do
   it { is_expected.to have_many(:appointment_summaries).through(:appointment_summaries_batches) }
   it { is_expected.to have_many(:appointment_summaries_batches).dependent(:destroy) }
+
+  it 'has a default #uploaded_at of nil' do
+    expect(subject.uploaded_at).to be_nil
+  end
 end

--- a/spec/models/batch_spec.rb
+++ b/spec/models/batch_spec.rb
@@ -7,4 +7,15 @@ RSpec.describe Batch, type: :model do
   it 'has a default #uploaded_at of nil' do
     expect(subject.uploaded_at).to be_nil
   end
+
+  describe '#mark_as_uploaded' do
+    it 'sets uploaded_at to now and saves the record' do
+      batch = Batch.create
+
+      batch.mark_as_uploaded
+      batch.reload
+
+      expect(batch.uploaded_at).to be_within(0.1.seconds).of Time.zone.now
+    end
+  end
 end

--- a/spec/models/batch_spec.rb
+++ b/spec/models/batch_spec.rb
@@ -18,4 +18,14 @@ RSpec.describe Batch, type: :model do
       expect(batch.uploaded_at).to be_within(0.1.seconds).of Time.zone.now
     end
   end
+
+  describe '.unprocessed' do
+    let(:uploaded_batches) { 3.times.map { Batch.create.tap(&:mark_as_uploaded) } }
+    let(:unuploaded_batches) { 3.times.map { Batch.create } }
+
+    subject(:batches) { Batch.unprocessed }
+
+    it { is_expected.to include(*unuploaded_batches) }
+    it { is_expected.not_to include(*uploaded_batches) }
+  end
 end

--- a/spec/services/create_batch_spec.rb
+++ b/spec/services/create_batch_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe CreateBatch, '#call' do
       format_preference: 'standard')
   end
 
-  context 'with no items to be processed' do
+  context 'with no items to be batched' do
     it { is_expected.to be_nil }
     specify { expect { batch }.to_not change { Batch.count } }
   end
 
-  context 'with items to be processed' do
+  context 'with items to be batched' do
     let!(:appointment_summaries) { 2.times.map { create_appointment_summary } }
 
     it { is_expected.to be_a(Batch) }

--- a/spec/services/print_house_sftp_uploader_spec.rb
+++ b/spec/services/print_house_sftp_uploader_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe UploadToPrintHouse, '#call' do
+RSpec.describe PrintHouseSFTPUploader, '#call' do
   let(:now) { Time.zone.local(2015, 1, 3, 5, 2, 4) }
   let(:csv) { 'c,s,v' }
   let(:csv_path) { '/Data.in/pensionwise_output_20150103050204000.csv' }

--- a/spec/services/print_house_sftp_uploader_spec.rb
+++ b/spec/services/print_house_sftp_uploader_spec.rb
@@ -13,19 +13,66 @@ RSpec.describe PrintHouseSFTPUploader, '#call' do
   let(:uploader) { described_class.new }
   before { allow(uploader).to receive(:upload_file) }
 
-  subject! { uploader.call(jobs) }
+  describe 'file uploads' do
+    subject! { uploader.call(jobs) }
 
-  it 'uploads data from all specified jobs' do
-    jobs.each do |job|
-      expect(uploader).to have_received(:upload_file).with(job.payload_path, job.payload)
-      expect(uploader).to have_received(:upload_file).with(job.trigger_path, job.trigger)
+    it 'uploads data from all specified jobs' do
+      jobs.each do |job|
+        expect(uploader).to have_received(:upload_file).with(job.payload_path, job.payload)
+        expect(uploader).to have_received(:upload_file).with(job.trigger_path, job.trigger)
+      end
+    end
+
+    it 'uploads trigger files after their respective payloads' do
+      jobs.each do |job|
+        expect(uploader).to have_received(:upload_file).with(job.payload_path, job.payload).ordered
+        expect(uploader).to have_received(:upload_file).with(job.trigger_path, job.trigger).ordered
+      end
     end
   end
 
-  it 'uploads trigger files after their respective payloads' do
-    jobs.each do |job|
-      expect(uploader).to have_received(:upload_file).with(job.payload_path, job.payload).ordered
-      expect(uploader).to have_received(:upload_file).with(job.trigger_path, job.trigger).ordered
+  describe 'error handling and notifications' do
+    let(:jobs_that_fail) { [jobs.first] }
+    let(:jobs_that_succeed)  { jobs - jobs_that_fail }
+    let(:failure_notifications) { [] }
+    let(:success_notifications) { [] }
+
+    before do
+      jobs_that_fail.each do |job|
+        allow(uploader).to receive(:upload_file)
+          .with(job.payload_path, job.payload).and_raise('upload failed!')
+      end
+
+      uploader.on(:upload_failed) { |*args| failure_notifications << args }
+      uploader.on(:upload_succeeded) { |*args| success_notifications << args }
+    end
+
+    subject! { uploader.call(jobs) }
+
+    it 'notifies subscribers for each successful upload' do
+      expect(success_notifications.count).to eq(jobs_that_succeed.count)
+    end
+
+    it 'includes the job in success notifications' do
+      successful_jobs = success_notifications.map { |args| args[0] }
+
+      expect(successful_jobs).to eq(jobs_that_succeed)
+    end
+
+    it 'notifies subscribers for each failed upload' do
+      expect(failure_notifications.count).to eq(jobs_that_fail.count)
+    end
+
+    it 'includes the job in failure notifications' do
+      failed_jobs = failure_notifications.map { |args| args[0] }
+
+      expect(failed_jobs).to eq(jobs_that_fail)
+    end
+
+    it 'includes the exception in failure notifications' do
+      exceptions = failure_notifications.map { |args| args[1] }
+
+      expect(exceptions).to all(be_a(StandardError))
     end
   end
 end

--- a/spec/services/print_house_sftp_uploader_spec.rb
+++ b/spec/services/print_house_sftp_uploader_spec.rb
@@ -13,13 +13,14 @@ RSpec.describe PrintHouseSFTPUploader, '#call' do
                                   trigger_path: trigger_path)
   end
 
-  subject(:uploader) { described_class.new(csv_upload_job) }
+  let(:uploader) { described_class.new }
 
   before do
     allow(uploader).to receive(:upload_file)
     allow(Time.zone).to receive(:today).and_return(now)
-    uploader.call
   end
+
+  subject! { uploader.call(csv_upload_job) }
 
   it 'uploads the CSV' do
     expect(uploader).to have_received(:upload_file).with(csv_path, csv)

--- a/spec/services/process_output_documents_spec.rb
+++ b/spec/services/process_output_documents_spec.rb
@@ -27,7 +27,10 @@ RSpec.describe ProcessOutputDocuments, '#call' do
         .with(batch).and_return(csv_upload_job)
 
       allow(PrintHouseSFTPUploader).to receive(:new)
-        .with(csv_upload_job).and_return(print_house)
+        .and_return(print_house)
+
+      allow(print_house).to receive(:call)
+        .with(csv_upload_job).and_return(result)
     end
 
     it { is_expected.to eq(result) }

--- a/spec/services/process_output_documents_spec.rb
+++ b/spec/services/process_output_documents_spec.rb
@@ -31,15 +31,4 @@ RSpec.describe ProcessOutputDocuments, '#call' do
 
     it { is_expected.to have_received(:call).with(unprocessed_batches) }
   end
-
-  describe 'does nothing when there are no unprocessed batches' do
-    before do
-      allow(Batch).to receive(:unprocessed).and_return([])
-      service.call
-    end
-
-    subject { upload_to_print_house }
-
-    it { is_expected.not_to have_received(:call) }
-  end
 end

--- a/spec/services/process_output_documents_spec.rb
+++ b/spec/services/process_output_documents_spec.rb
@@ -20,13 +20,13 @@ RSpec.describe ProcessOutputDocuments, '#call' do
     let(:batch) { instance_double(Batch, appointment_summaries: [appointment_summary]) }
     let(:csv_upload_job) { instance_double(CSVUploadJob) }
     let(:result) { 'result' }
-    let(:print_house) { instance_double(UploadToPrintHouse, call: result) }
+    let(:print_house) { instance_double(PrintHouseSFTPUploader, call: result) }
 
     before do
       allow(CSVUploadJob).to receive(:new)
         .with(batch).and_return(csv_upload_job)
 
-      allow(UploadToPrintHouse).to receive(:new)
+      allow(PrintHouseSFTPUploader).to receive(:new)
         .with(csv_upload_job).and_return(print_house)
     end
 

--- a/spec/services/process_output_documents_spec.rb
+++ b/spec/services/process_output_documents_spec.rb
@@ -16,21 +16,16 @@ RSpec.describe ProcessOutputDocuments, '#call' do
   end
 
   context 'with items for processing' do
-    let(:appointment_summary) { instance_double(AppointmentSummary) }
-    let(:batch) { instance_double(Batch, appointment_summaries: [appointment_summary]) }
-    let(:csv_upload_job) { instance_double(CSVUploadJob) }
+    let(:batch) { instance_double(Batch) }
     let(:result) { 'result' }
-    let(:print_house) { instance_double(PrintHouseSFTPUploader, call: result) }
+    let(:upload_to_print_house) { instance_double(UploadToPrintHouse) }
 
     before do
-      allow(CSVUploadJob).to receive(:new)
-        .with(batch).and_return(csv_upload_job)
+      allow(UploadToPrintHouse).to receive(:new)
+        .and_return(upload_to_print_house)
 
-      allow(PrintHouseSFTPUploader).to receive(:new)
-        .and_return(print_house)
-
-      allow(print_house).to receive(:call)
-        .with(csv_upload_job).and_return(result)
+      allow(upload_to_print_house).to receive(:call)
+        .with(batch).and_return(result)
     end
 
     it { is_expected.to eq(result) }

--- a/spec/services/process_output_documents_spec.rb
+++ b/spec/services/process_output_documents_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe ProcessOutputDocuments, '#call' do
   before do
     allow(CreateBatch).to receive(:new).and_return(create_batch)
     allow(UploadToPrintHouse).to receive(:new).and_return(upload_to_print_house)
+    allow(Batch).to receive(:unprocessed)
   end
 
   describe 'creates a new batch' do
@@ -18,22 +19,22 @@ RSpec.describe ProcessOutputDocuments, '#call' do
     it { is_expected.to have_received(:call) }
   end
 
-  describe 'uploads the created batch to the print house' do
-    let(:batch) { instance_double(Batch) }
+  describe 'uploads all unprocessed batches to the print house' do
+    let(:unprocessed_batches) { 3.times.map { instance_double(Batch) } }
 
     before do
-      allow(create_batch).to receive(:call).and_return(batch)
+      allow(Batch).to receive(:unprocessed).and_return(unprocessed_batches)
       service.call
     end
 
     subject { upload_to_print_house }
 
-    it { is_expected.to have_received(:call).with(batch) }
+    it { is_expected.to have_received(:call).with(unprocessed_batches) }
   end
 
   describe 'does nothing when there are no unprocessed batches' do
     before do
-      allow(create_batch).to receive(:call).and_return(nil)
+      allow(Batch).to receive(:unprocessed).and_return([])
       service.call
     end
 

--- a/spec/services/upload_to_print_house_spec.rb
+++ b/spec/services/upload_to_print_house_spec.rb
@@ -56,4 +56,14 @@ RSpec.describe UploadToPrintHouse, '#call' do
 
     it { is_expected.not_to have_received(:mark_as_uploaded) }
   end
+
+  [nil, []].each do |no_batches|
+    context "with #{no_batches.inspect} batches" do
+      before { upload_to_print_house.call(no_batches) }
+
+      subject { print_house_sftp_uploader }
+
+      it { is_expected.not_to have_received(:call) }
+    end
+  end
 end

--- a/spec/services/upload_to_print_house_spec.rb
+++ b/spec/services/upload_to_print_house_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe UploadToPrintHouse, '#call' do
+  let(:batch_one) { instance_double(Batch).as_null_object }
+  let(:batch_two) { instance_double(Batch).as_null_object }
+  let(:batch_three) { instance_double(Batch).as_null_object }
+  let(:job_one) { instance_double(CSVUploadJob, batch: batch_one).as_null_object }
+  let(:job_two) { instance_double(CSVUploadJob, batch: batch_two).as_null_object }
+  let(:job_three) { instance_double(CSVUploadJob, batch: batch_three).as_null_object }
+  let(:print_house_sftp_uploader) { instance_double(PrintHouseSFTPUploader).as_null_object }
+  let(:upload_to_print_house) { described_class.new }
+
+  before do
+    allow(CSVUploadJob).to receive(:new).with(batch_one).and_return(job_one)
+    allow(CSVUploadJob).to receive(:new).with(batch_two).and_return(job_two)
+    allow(CSVUploadJob).to receive(:new).with(batch_three).and_return(job_three)
+    allow(PrintHouseSFTPUploader).to receive(:new).and_return(print_house_sftp_uploader)
+  end
+
+  describe 'uploads the specified batches to the print house' do
+    before { upload_to_print_house.call([batch_one, batch_two, batch_three]) }
+
+    subject { print_house_sftp_uploader }
+
+    it { is_expected.to have_received(:call).with([job_one, job_two, job_three]) }
+  end
+end


### PR DESCRIPTION
`ProcessOutputDocuments#call` will now upload all unprocessed (i.e. not yet uploaded) batches.

Adds [Wisper](https://github.com/krisleech/wisper) for pub/sub, which provides far more control than [ActiveSupport::Notifications](http://api.rubyonrails.org/classes/ActiveSupport/Notifications.html) and better expresses intention.

I think that this can be merged as a single PR, as no production code currently creates or reads batches.
