### PR TITLE
Upload all unprocessed batches (option B)

### DIFF
--- a/app/models/appointment_summary.rb
+++ b/app/models/appointment_summary.rb
@@ -2,7 +2,7 @@ require 'json'
 require 'uri'
 
 class AppointmentSummary < ActiveRecord::Base
-  scope :unprocessed, lambda {
+  scope :unbatched, lambda {
     includes(:appointment_summaries_batches)
       .where(appointment_summaries_batches: { appointment_summary_id: nil })
   }

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -1,4 +1,6 @@
 class Batch < ActiveRecord::Base
+  scope :unprocessed, -> { where(uploaded_at: nil) }
+
   has_many :appointment_summaries_batches, dependent: :destroy
   has_many :appointment_summaries, through: :appointment_summaries_batches
 

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -1,4 +1,8 @@
 class Batch < ActiveRecord::Base
   has_many :appointment_summaries_batches, dependent: :destroy
   has_many :appointment_summaries, through: :appointment_summaries_batches
+
+  def mark_as_uploaded
+    update(uploaded_at: Time.zone.now)
+  end
 end

--- a/app/services/create_batch.rb
+++ b/app/services/create_batch.rb
@@ -1,11 +1,11 @@
 class CreateBatch
   def call
-    unprocessed_appointment_summaries = AppointmentSummary.unprocessed
-                                        .where(format_preference: :standard)
-                                        .where(country: Countries.uk)
+    unbatched_appointment_summaries = AppointmentSummary.unbatched
+                                      .where(format_preference: :standard)
+                                      .where(country: Countries.uk)
 
-    return nil if unprocessed_appointment_summaries.empty?
+    return nil if unbatched_appointment_summaries.empty?
 
-    Batch.create(appointment_summaries: unprocessed_appointment_summaries)
+    Batch.create(appointment_summaries: unbatched_appointment_summaries)
   end
 end

--- a/app/services/process_output_documents.rb
+++ b/app/services/process_output_documents.rb
@@ -1,13 +1,18 @@
 class ProcessOutputDocuments
   def call
-    batch = CreateBatch.new.call
+    CreateBatch.new.call
+    upload_all(Batch.unprocessed)
+  end
 
-    return nil unless batch
+  private
 
-    csv_upload_job = CSVUploadJob.new(batch)
+  def upload_all(batches)
+    Array(batches).each { |batch| upload(batch) }
+  end
 
-    UploadToPrintHouse.new(csv_upload_job).call
-
+  def upload(batch)
+    job = CSVUploadJob.new(batch)
+    UploadToPrintHouse.new(job).call
     batch.mark_as_uploaded
   end
 end

--- a/app/services/process_output_documents.rb
+++ b/app/services/process_output_documents.rb
@@ -7,5 +7,7 @@ class ProcessOutputDocuments
     csv_upload_job = CSVUploadJob.new(batch)
 
     UploadToPrintHouse.new(csv_upload_job).call
+
+    batch.mark_as_uploaded
   end
 end

--- a/db/migrate/20150427131314_remove_processed_at_from_batches.rb
+++ b/db/migrate/20150427131314_remove_processed_at_from_batches.rb
@@ -1,0 +1,5 @@
+class RemoveProcessedAtFromBatches < ActiveRecord::Migration
+  def change
+    remove_column :batches, :processed_at
+  end
+end

--- a/db/migrate/20150427131639_add_uploaded_at_to_batches.rb
+++ b/db/migrate/20150427131639_add_uploaded_at_to_batches.rb
@@ -1,0 +1,5 @@
+class AddUploadedAtToBatches < ActiveRecord::Migration
+  def change
+    add_column :batches, :uploaded_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150427100026) do
+ActiveRecord::Schema.define(version: 20150427131639) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,9 +60,9 @@ ActiveRecord::Schema.define(version: 20150427100026) do
   add_index "appointment_summaries_batches", ["batch_id"], name: "index_appointment_summaries_batches_on_batch_id", using: :btree
 
   create_table "batches", force: :cascade do |t|
-    t.datetime "processed_at"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+    t.datetime "uploaded_at"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/models/appointment_summary_spec.rb
+++ b/spec/models/appointment_summary_spec.rb
@@ -133,8 +133,8 @@ RSpec.describe AppointmentSummary, type: :model do
     end
   end
 
-  describe '.unprocessed' do
-    subject { described_class.unprocessed }
+  describe '.unbatched' do
+    subject { described_class.unbatched }
 
     def create_appointment_summary
       AppointmentSummary.create(
@@ -144,20 +144,20 @@ RSpec.describe AppointmentSummary, type: :model do
         has_defined_contribution_pension: 'yes', income_in_retirement: 'pension')
     end
 
-    context 'with no unprocessed items' do
+    context 'with no unbatched items' do
       let!(:appointment_summaries) { 2.times.map { create_appointment_summary } }
       let!(:previous_batch) { Batch.create(appointment_summaries: appointment_summaries) }
 
       it { is_expected.to be_empty }
     end
 
-    context 'with unprocessed items' do
+    context 'with unbatched items' do
       let!(:appointment_summaries) { 2.times.map { create_appointment_summary } }
 
       it { is_expected.to eq(appointment_summaries) }
     end
 
-    context 'with processed and unprocessed items' do
+    context 'with batched and unbatched items' do
       let!(:appointment_summaries) { 4.times.map { create_appointment_summary } }
       let!(:previous_batch) { Batch.create(appointment_summaries: appointment_summaries[0..1]) }
 

--- a/spec/models/batch_spec.rb
+++ b/spec/models/batch_spec.rb
@@ -11,4 +11,12 @@ RSpec.describe Batch, type: :model do
 
     it { is_expected.to be_nil }
   end
+
+  describe '#mark_as_uploaded' do
+    before { batch.mark_as_uploaded }
+
+    it 'saves uploaded_at as now' do
+      expect(batch.reload.uploaded_at).to be_within(0.1.seconds).of Time.zone.now
+    end
+  end
 end

--- a/spec/models/batch_spec.rb
+++ b/spec/models/batch_spec.rb
@@ -3,4 +3,12 @@ require 'rails_helper'
 RSpec.describe Batch, type: :model do
   it { is_expected.to have_many(:appointment_summaries).through(:appointment_summaries_batches) }
   it { is_expected.to have_many(:appointment_summaries_batches).dependent(:destroy) }
+
+  let(:batch) { described_class.new }
+
+  describe '#uploaded_at' do
+    subject { batch.uploaded_at }
+
+    it { is_expected.to be_nil }
+  end
 end

--- a/spec/models/batch_spec.rb
+++ b/spec/models/batch_spec.rb
@@ -19,4 +19,14 @@ RSpec.describe Batch, type: :model do
       expect(batch.reload.uploaded_at).to be_within(0.1.seconds).of Time.zone.now
     end
   end
+
+  describe '.unprocessed' do
+    let(:uploaded_batches) { 3.times.map { Batch.create.tap(&:mark_as_uploaded) } }
+    let(:unuploaded_batches) { 3.times.map { Batch.create } }
+
+    subject(:batches) { Batch.unprocessed }
+
+    it { is_expected.to include(*unuploaded_batches) }
+    it { is_expected.not_to include(*uploaded_batches) }
+  end
 end

--- a/spec/services/create_batch_spec.rb
+++ b/spec/services/create_batch_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe CreateBatch, '#call' do
       format_preference: 'standard')
   end
 
-  context 'with no items to be processed' do
+  context 'with no items to be batched' do
     it { is_expected.to be_nil }
     specify { expect { batch }.to_not change { Batch.count } }
   end
 
-  context 'with items to be processed' do
+  context 'with items to be batched' do
     let!(:appointment_summaries) { 2.times.map { create_appointment_summary } }
 
     it { is_expected.to be_a(Batch) }

--- a/spec/services/process_output_documents_spec.rb
+++ b/spec/services/process_output_documents_spec.rb
@@ -26,6 +26,12 @@ RSpec.describe ProcessOutputDocuments, '#call' do
     it { is_expected.to have_received(:call) }
   end
 
+  describe 'marks the batch as uploaded' do
+    subject { batch }
+
+    it { is_expected.to have_received(:mark_as_uploaded) }
+  end
+
   context 'when no items for processing' do
     let(:batch) { nil }
 


### PR DESCRIPTION
Simpler version of #149.

Changes less about the existing implementation, doesn't need pub/sub, fewer moving parts, fewer interdependencies.