### PR TITLE
Retry print-house uploads up to 5 times

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'pg'
 gem 'puma'
 gem 'rails', '4.2.0'
 gem 'rails-i18n', '~> 4.0.0'
+gem 'retriable'
 gem 'sass-rails', '~> 5.0'
 gem 'sidekiq'
 gem 'sinatra', require: nil # Sidekiq UI

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,6 +199,7 @@ GEM
       redis (~> 3.0, >= 3.0.4)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)
+    retriable (2.0.2)
     rspec-core (3.2.3)
       rspec-support (~> 3.2.0)
     rspec-expectations (3.2.1)
@@ -308,6 +309,7 @@ DEPENDENCIES
   rails (= 4.2.0)
   rails-i18n (~> 4.0.0)
   rails_12factor
+  retriable
   rspec-rails
   rubocop
   sass-rails (~> 5.0)

--- a/app/services/upload_to_print_house.rb
+++ b/app/services/upload_to_print_house.rb
@@ -9,7 +9,7 @@ class UploadToPrintHouse
   end
 
   def call
-    Retriable.retriable(tries: 6) do
+    Retriable.retriable(tries: 6, on_retry: method(:on_retry)) do
       upload_file(job.payload_path, job.payload)
       upload_file(job.trigger_path, job.trigger)
     end
@@ -28,5 +28,9 @@ class UploadToPrintHouse
 
   def logger
     Rails.logger
+  end
+
+  def on_retry(exception, try, _, _)
+    logger.warn "Upload error (attempt #{try}). #{exception.class}: '#{exception.message}'"
   end
 end

--- a/app/services/upload_to_print_house.rb
+++ b/app/services/upload_to_print_house.rb
@@ -9,8 +9,10 @@ class UploadToPrintHouse
   end
 
   def call
-    upload_file(job.payload_path, job.payload)
-    upload_file(job.trigger_path, job.trigger)
+    attempt(5) do
+      upload_file(job.payload_path, job.payload)
+      upload_file(job.trigger_path, job.trigger)
+    end
   end
 
   private
@@ -26,5 +28,13 @@ class UploadToPrintHouse
 
   def logger
     Rails.logger
+  end
+
+  def attempt(times)
+    attempts ||= 0
+    yield
+  rescue
+    retry unless (attempts += 1) > times
+    raise
   end
 end

--- a/app/services/upload_to_print_house.rb
+++ b/app/services/upload_to_print_house.rb
@@ -9,7 +9,7 @@ class UploadToPrintHouse
   end
 
   def call
-    attempt(5) do
+    Retriable.retriable(tries: 6) do
       upload_file(job.payload_path, job.payload)
       upload_file(job.trigger_path, job.trigger)
     end
@@ -28,13 +28,5 @@ class UploadToPrintHouse
 
   def logger
     Rails.logger
-  end
-
-  def attempt(times)
-    attempts ||= 0
-    yield
-  rescue
-    retry unless (attempts += 1) > times
-    raise
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require 'retriable'
+
 RSpec.configure do |config|
   config.default_formatter = 'doc' if config.files_to_run.one?
   config.disable_monkey_patching!
@@ -15,4 +17,8 @@ RSpec.configure do |config|
   end
 
   Kernel.srand config.seed
+end
+
+Retriable.configure do |c|
+  c.base_interval = 0
 end


### PR DESCRIPTION
Adds naïve fault tolerance to the print-house uploads. A more sophisticated implementation would add random exponential backoff, but I'm not sure its needed in this case. Thoughts?