### PR TITLE
Use tagged logging for key stages of PrintHouse integration

### DIFF
--- a/app/services/create_batch.rb
+++ b/app/services/create_batch.rb
@@ -6,6 +6,12 @@ class CreateBatch
 
     return nil if unbatched_appointment_summaries.empty?
 
-    Batch.create(appointment_summaries: unbatched_appointment_summaries)
+    Batch.create(appointment_summaries: unbatched_appointment_summaries).tap do |b|
+      logger.info("Batch #{b.id} created with #{b.appointment_summaries.count} item(s)")
+    end
+  end
+
+  def logger
+    Rails.logger
   end
 end

--- a/app/services/process_output_documents.rb
+++ b/app/services/process_output_documents.rb
@@ -1,7 +1,20 @@
 class ProcessOutputDocuments
+  attr_reader :tags
+
+  def initialize
+    @tags = [self.class, SecureRandom.uuid]
+  end
+
   def call
+    logger.push_tags(tags)
+    logger.info('Start')
+
     CreateBatch.new.call
     upload_all(Batch.unprocessed)
+
+    logger.info('End')
+  ensure
+    logger.pop_tags(tags.size)
   end
 
   private
@@ -11,8 +24,14 @@ class ProcessOutputDocuments
   end
 
   def upload(batch)
+    logger.info("Processing batch #{batch.id}")
+
     job = CSVUploadJob.new(batch)
     UploadToPrintHouse.new(job).call
     batch.mark_as_uploaded
+  end
+
+  def logger
+    Rails.logger
   end
 end

--- a/app/services/upload_to_print_house.rb
+++ b/app/services/upload_to_print_house.rb
@@ -16,9 +16,15 @@ class UploadToPrintHouse
   private
 
   def upload_file(path, contents)
+    logger.info("Uploading #{path}")
+
     io = StringIO.new(contents)
     Net::SFTP.start(ENV['SFTP_HOST'], ENV['SFTP_USER'], password: ENV['SFTP_PASSWORD']) do |sftp|
       sftp.upload!(io, path)
     end
+  end
+
+  def logger
+    Rails.logger
   end
 end


### PR DESCRIPTION
Instead of performing everything with a block passed to `ActiveSupport::TaggedLogging#tagged` we can make use of the public API on offer and simply push and pop tags as we see fit. For better or for worse tags are [stored on Thread.current](https://github.com/rails/rails/blob/f046e8a70fe526ebcea88ea1d084eb4b634b653b/activesupport/lib/active_support/tagged_logging.rb#L46). It's up for debate wether this is a valid approach or not.

Produces the following output:

![image](https://cloud.githubusercontent.com/assets/45121/7394669/f7f66a54-ee8c-11e4-9feb-0082a48ddd3a.png)

Apart from the SQL logging, the key stages logged are:

* start
* id and number of contents upon batch creation
* id of batch to be uploaded
* paths of individual files to be uploaded
* end

A simplification could be `CreateBatch` and `UploadToPrintHouse` accessing `Rails.logger` directly rather than setting an instance variable.

Opinions gents?