### PR TITLE
User name

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,16 +11,4 @@ class User < ActiveRecord::Base
   def name
     [first_name, last_name].join(' ').strip
   end
-
-  def first_name
-    super || self[:name].try do |name|
-      name.split(' ').first
-    end
-  end
-
-  def last_name
-    super || self[:name].try do |name|
-      name.split(' ').last
-    end
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,16 +9,7 @@ class User < ActiveRecord::Base
   end
 
   def name
-    super || [first_name, last_name].join(' ').strip
-  end
-
-  def name=(name)
-    first_name, last_name = name.split(' ')
-
-    self.first_name = first_name
-    self.last_name = last_name
-
-    super
+    [first_name, last_name].join(' ').strip
   end
 
   def first_name

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,42 +5,8 @@ RSpec.describe User, type: :model do
 
   it { is_expected.to have_many(:appointment_summaries) }
 
-  context 'when a full name is set' do
-    subject { described_class.new(name: 'Joe Bloggs') }
-
-    it 'has a name' do
-      expect(subject.name).to eq('Joe Bloggs')
-    end
-
-    it 'has a first name' do
-      expect(subject.first_name).to eq('Joe')
-    end
-
-    it 'has a last name' do
-      expect(subject.last_name).to eq('Bloggs')
-    end
-  end
-
   context 'when a first name and last name is set' do
     subject { described_class.new(first_name: 'Joe', last_name: 'Bloggs') }
-
-    it 'has a name' do
-      expect(subject.name).to eq('Joe Bloggs')
-    end
-
-    it 'has a first name' do
-      expect(subject.first_name).to eq('Joe')
-    end
-
-    it 'has a last name' do
-      expect(subject.last_name).to eq('Bloggs')
-    end
-  end
-
-  context 'with an existing full name' do
-    before do
-      allow(subject).to receive(:read_attribute).with(:name) { 'Joe Bloggs' }
-    end
 
     it 'has a name' do
       expect(subject.name).to eq('Joe Bloggs')


### PR DESCRIPTION
Depend on the `first_name` and `last_name` attributes, ignoring the redundant `name`.

This needs to be run before the deployment/migration to accommodate legacy data:
```ruby
User.where(first_name: nil, last_name: nil).where.not(name: nil).each { |u| u.first_name = u.first_name; u.last_name = u.last_name; u.save }
```