### PR TITLE
Ignore id and timestamp columns correctly

### DIFF
--- a/app/views/appointment_summaries/preview.html.erb
+++ b/app/views/appointment_summaries/preview.html.erb
@@ -6,7 +6,7 @@
 
 <%= form_for @appointment_summary, url: appointment_summaries_path do |f| %>
 
-  <% (AppointmentSummary.columns - [:id, :created_at, :updated_at, :user_id]).map(&:name).each do |field| %>
+  <% (AppointmentSummary.columns.map(&:name) - %w(id created_at updated_at user_id)).each do |field| %>
     <%= f.hidden_field field %>
   <% end %>
 


### PR DESCRIPTION
The existing code still includes `id`, `created_at`, `updated_at` and `user_id`:
```ruby
> (AppointmentSummary.columns - [:id, :created_at, :updated_at, :user_id]).map(&:name)
=> ["id",
 "created_at",
 "updated_at",
 "date_of_appointment",
 "value_of_pension_pots",
 "income_in_retirement",
 "guider_organisation",
 "guider_name",
 "continue_working",
 "unsure",
 "leave_inheritance",
 "wants_flexibility",
 "wants_security",
 "wants_lump_sum",
 "poor_health",
 "user_id",
 "reference_number",
 "address_line_1",
 "address_line_2",
 "address_line_3",
 "town",
 "county",
 "postcode",
 "title",
 "first_name",
 "last_name",
 "format_preference",
 "has_defined_contribution_pension",
 "upper_value_of_pension_pots",
 "value_of_pension_pots_is_approximate",
 "country"]
```

The proposed:
```ruby
 > (AppointmentSummary.columns.map(&:name) - %w(id created_at updated_at user_id))
=> ["date_of_appointment",
 "value_of_pension_pots",
 "income_in_retirement",
 "guider_organisation",
 "guider_name",
 "continue_working",
 "unsure",
 "leave_inheritance",
 "wants_flexibility",
 "wants_security",
 "wants_lump_sum",
 "poor_health",
 "reference_number",
 "address_line_1",
 "address_line_2",
 "address_line_3",
 "town",
 "county",
 "postcode",
 "title",
 "first_name",
 "last_name",
 "format_preference",
 "has_defined_contribution_pension",
 "upper_value_of_pension_pots",
 "value_of_pension_pots_is_approximate",
 "country"]
```