### PR TITLE
Approximate non-ASCII characters

### DIFF
--- a/app/models/csv_upload_job.rb
+++ b/app/models/csv_upload_job.rb
@@ -7,7 +7,7 @@ class CSVUploadJob
 
   def payload
     output_documents = batch.appointment_summaries.map do |appointment_summary|
-      OutputDocument.new(appointment_summary)
+      OutputDocument.new(TransliteratedAppointmentSummary.new(appointment_summary))
     end
 
     CSVRenderer.new(output_documents).render

--- a/app/models/transliterated_appointment_summary.rb
+++ b/app/models/transliterated_appointment_summary.rb
@@ -1,0 +1,9 @@
+class TransliteratedAppointmentSummary < SimpleDelegator
+  %i(first_name last_name guider_name
+     address_line_1 address_line_2 address_line_3
+     town county postcode country).each do |method_name|
+    define_method(method_name) do
+      I18n.transliterate(super())
+    end
+  end
+end

--- a/features/step_definitions/covering_letter_steps.rb
+++ b/features/step_definitions/covering_letter_steps.rb
@@ -3,17 +3,14 @@ Given(/^a customer has had a Pension Wise appointment$/) do
 end
 
 Then(/^it should include a covering letter$/) do
-  output_document = OutputDocument.new(@appointment_summary)
-  expected = {
-    attendee_address_line_1: output_document.attendee_address_line_1,
-    attendee_address_line_2: output_document.attendee_address_line_2,
-    attendee_address_line_3: output_document.attendee_address_line_3,
-    attendee_town: output_document.attendee_town,
-    attendee_county: output_document.attendee_county,
-    attendee_postcode: output_document.attendee_postcode,
-    attendee_name: output_document.attendee_name,
-    lead: output_document.lead
-  }
+  expected = fixture(:populated_csv).slice(%i(attendee_address_line_1
+                                              attendee_address_line_2
+                                              attendee_address_line_3
+                                              attendee_town
+                                              attendee_county
+                                              attendee_postcode
+                                              attendee_name
+                                              lead))
 
   expect_uploaded_csv_to_include(expected)
 end

--- a/features/step_definitions/record_of_guidance_contents_steps.rb
+++ b/features/step_definitions/record_of_guidance_contents_steps.rb
@@ -120,12 +120,7 @@ Given(/^(?:I|we) have captured the customer's details in an appointment summary$
 end
 
 Then(/^the record of guidance should include their details$/) do
-  output_document = OutputDocument.new(@appointment_summary)
-
-  expected = {
-    attendee_name: output_document.attendee_name,
-    value_of_pension_pots: output_document.value_of_pension_pots
-  }
+  expected = fixture(:populated_csv).slice(%i(attendee_name value_of_pension_pots))
 
   expect_uploaded_csv_to_include(expected)
 end
@@ -135,16 +130,12 @@ Given(/^(?:I|we) have captured appointment details in an appointment summary$/) 
 end
 
 Then(/^the record of guidance should include the details of the appointment$/) do
-  output_document = OutputDocument.new(@appointment_summary)
-
-  expected = {
-    appointment_date: output_document.appointment_date,
-    guider_first_name: output_document.guider_first_name,
-    guider_organisation: output_document.guider_organisation
-  }
+  expected = fixture(:populated_csv).slice(%i(appointment_date guider_first_name guider_organisation))
 
   expect_uploaded_csv_to_include(expected)
 
   appointment_reference = read_uploaded_csv.first[:appointment_reference]
-  expect(appointment_reference).to match(/^\d+#{output_document.appointment_reference}/)
+  expected_reference = %r{^\d+/#{@appointment_summary.reference_number}$}
+
+  expect(appointment_reference).to match(expected_reference)
 end

--- a/features/support/fixtures.rb
+++ b/features/support/fixtures.rb
@@ -7,11 +7,11 @@ module Fixtures
     populated_appointment_summary: proc do
       AppointmentSummary.new(
         title: 'Mr',
-        first_name: 'Joe',
-        last_name: 'Bloggs',
+        first_name: 'Joé',
+        last_name: 'Bløggs',
         address_line_1: 'HM Treasury',
-        address_line_2: '1 Horse Guards Road',
-        address_line_3: 'Westminster',
+        address_line_2: '1 Hôrse Guârds Roåd',
+        address_line_3: 'Weštminstęr',
         town: 'London',
         county: 'Greater London',
         country: 'United Kingdom',
@@ -22,7 +22,7 @@ module Fixtures
         upper_value_of_pension_pots: 55_000,
         value_of_pension_pots_is_approximate: true,
         income_in_retirement: 'pension',
-        guider_name: 'Penelope',
+        guider_name: 'Pênelopę',
         guider_organisation: 'tpas',
         has_defined_contribution_pension: 'yes',
         continue_working: true,
@@ -34,6 +34,34 @@ module Fixtures
         poor_health: true,
         format_preference: 'standard'
       )
+    end,
+
+    populated_csv: proc do
+      {
+        format: 'standard',
+        variant: 'tailored',
+        guider_first_name: 'Penelope',
+        guider_organisation: 'The Pensions Advisory Service',
+        appointment_date: '5 February 2015',
+        lead: 'You recently had a Pension Wise guidance appointment with Penelope from ' \
+              'The Pensions Advisory Service on 5 February 2015.',
+        value_of_pension_pots: '£35,000 to £55,000',
+        income_in_retirement: 'pension',
+        attendee_name: 'Mr Joe Bloggs',
+        attendee_address_line_1: 'HM Treasury',
+        attendee_address_line_2: '1 Horse Guards Road',
+        attendee_address_line_3: 'Westminster',
+        attendee_town: 'London',
+        attendee_county: 'Greater London',
+        attendee_postcode: 'SW1A 2HQ',
+        continue_working: true,
+        leave_inheritance: true,
+        poor_health: true,
+        unsure: true,
+        wants_flexibility: true,
+        wants_lump_sum: true,
+        wants_security: true
+      }
     end
   }
 

--- a/spec/models/transliterated_appointment_summary_spec.rb
+++ b/spec/models/transliterated_appointment_summary_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe TransliteratedAppointmentSummary do
+  transliterated_fields = %i(first_name
+                             last_name
+                             address_line_1
+                             address_line_2
+                             address_line_3
+                             town
+                             county
+                             postcode
+                             country
+                             guider_name)
+
+  transliterated_fields.each do |field|
+    describe ".#{field}" do
+      subject do
+        appointment_summary = instance_double(AppointmentSummary, field => 'abc123!@$%àéïöüçß')
+
+        described_class.new(appointment_summary).public_send(field)
+      end
+
+      it 'approximates non-ASCII characters' do
+        is_expected.to eq('abc123!@$%aeioucss')
+      end
+    end
+  end
+end


### PR DESCRIPTION
The font we use to render output documents has a limited character set so we need to remove unsupported characters.