### PR TITLE
Ignore county in postcode search response

### DIFF
--- a/app/assets/javascripts/postcode-lookup.js
+++ b/app/assets/javascripts/postcode-lookup.js
@@ -27,7 +27,6 @@
           line_2: '#appointment_summary_address_line_2',
           line_3: '#appointment_summary_address_line_3',
           post_town: '#appointment_summary_town',
-          county: '#appointment_summary_county',
           postcode: '#appointment_summary_postcode'
         }
       });


### PR DESCRIPTION
It is misleading and causing confusion amongst guiders. It is also not used for mail routing, and Ideal-Postcodes recommends not using it.