### PR TITLE
Allow blank titles

### DIFF
--- a/app/models/appointment_summary.rb
+++ b/app/models/appointment_summary.rb
@@ -20,7 +20,7 @@ class AppointmentSummary < ActiveRecord::Base
   belongs_to :user
   has_many :appointment_summaries_batches, dependent: :destroy
 
-  validates :title, presence: true, inclusion: { in: TITLES, allow_blank: true }
+  validates :title, inclusion: { in: TITLES, allow_blank: true }
   validates :last_name, presence: true
   validates :date_of_appointment, timeliness: { on_or_before: -> { Time.zone.today },
                                                 on_or_after: Date.new(2015),

--- a/spec/models/appointment_summary_spec.rb
+++ b/spec/models/appointment_summary_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe AppointmentSummary, type: :model do
   it { is_expected.to belong_to(:user) }
   it { is_expected.to have_many(:appointment_summaries_batches).dependent(:destroy) }
 
-  it { is_expected.to validate_presence_of(:title) }
+  it { is_expected.to_not validate_presence_of(:title) }
   it { is_expected.to_not validate_presence_of(:first_name) }
   it { is_expected.to validate_presence_of(:last_name) }
 
-  it { is_expected.to validate_inclusion_of(:title).in_array(%w(Mr Mrs Miss Ms Mx Dr Reverend)) }
+  it { is_expected.to validate_inclusion_of(:title).in_array(%w(Mr Mrs Miss Ms Mx Dr Reverend)).allow_blank }
   it { is_expected.to_not allow_value('Alien').for(:title) }
 
   it { is_expected.to allow_value('2015-02-10').for(:date_of_appointment) }


### PR DESCRIPTION
It allows a little more flexibility, but adds the risk that a blank title and first_name leads to a "Dear Smith" salutation on a covering letter.