### PR TITLE
Use API token when accessing Github

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ node_js:
 - '0.10'
 rvm:
 - 2.2.2
+before_install:
+- echo -e "machine github.com\n  login $CI_USER_TOKEN" >> ~/.netrc
 before_script:
 - npm install
 - "./bin/rake db:setup RAILS_ENV=test"

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ source 'https://rubygems.org'
 
 ruby '2.2.2'
 
-# force Bundler to use SSH for github repos
-git_source(:github) { |repo_name| "git@github.com:#{repo_name}.git" }
+# force Bundler to use HTTPS for github repos
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
 gem 'autoprefixer-rails'
 gem 'bugsnag'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git@github.com:andrewgarner/govuk_admin_template.git
+  remote: https://github.com/andrewgarner/govuk_admin_template.git
   revision: c0ba6e52dbd76236aaab8705838ae4da008aace8
   branch: configurable-analytics
   specs:
@@ -9,7 +9,7 @@ GIT
       rails (>= 3.2.0)
 
 GIT
-  remote: git@github.com:guidance-guarantee-programme/output-templates.git
+  remote: https://github.com/guidance-guarantee-programme/output-templates.git
   revision: c2cdd85444eb96cb16f6548cdc020df65753f852
   specs:
     output-templates (1.1.0)


### PR DESCRIPTION
We can use an API token for the CI user [per the documentation](http://docs.travis-ci.com/user/private-dependencies/#API-Token).

Consequence is that we have to fetch the dependencies via HTTPS, not SSH.