### PR TITLE
Slice the hash correctly

### DIFF
--- a/features/step_definitions/covering_letter_steps.rb
+++ b/features/step_definitions/covering_letter_steps.rb
@@ -3,14 +3,14 @@ Given(/^a customer has had a Pension Wise appointment$/) do
 end
 
 Then(/^it should include a covering letter$/) do
-  expected = fixture(:populated_csv).slice(%i(attendee_address_line_1
-                                              attendee_address_line_2
-                                              attendee_address_line_3
-                                              attendee_town
-                                              attendee_county
-                                              attendee_postcode
-                                              attendee_name
-                                              lead))
+  expected = fixture(:populated_csv).slice(*%i(attendee_address_line_1
+                                               attendee_address_line_2
+                                               attendee_address_line_3
+                                               attendee_town
+                                               attendee_county
+                                               attendee_postcode
+                                               attendee_name
+                                               lead))
 
   expect_uploaded_csv_to_include(expected)
 end


### PR DESCRIPTION
`Hash#slice` requires a list of parameters, not an array.