### PR TITLE
Conditionally include or exclude attendee_country

### DIFF
--- a/app/domain/output_document.rb
+++ b/app/domain/output_document.rb
@@ -9,7 +9,7 @@ class OutputDocument
            :format_preference, :appointment_type,
            to: :appointment_summary
 
-  delegate :address_line_1, :address_line_2, :address_line_3, :town, :county, :postcode, :country,
+  delegate :address_line_1, :address_line_2, :address_line_3, :town, :county, :postcode,
            to: :appointment_summary, prefix: :attendee
 
   def initialize(appointment_summary)
@@ -20,9 +20,11 @@ class OutputDocument
     "#{appointment_summary.title} #{appointment_summary.first_name} #{appointment_summary.last_name}".squish
   end
 
-  def attendee_address
-    attendee_country = Countries.uk?(self.attendee_country) ? nil : self.attendee_country
+  def attendee_country
+    Countries.uk?(appointment_summary.country) ? nil : appointment_summary.country
+  end
 
+  def attendee_address
     [attendee_name,
      attendee_address_line_1,
      attendee_address_line_2,

--- a/spec/domain/output_document_spec.rb
+++ b/spec/domain/output_document_spec.rb
@@ -49,6 +49,26 @@ RSpec.describe OutputDocument do
   specify { expect(output_document.attendee_name).to eq(attendee_name) }
   specify { expect(output_document.appointment_date).to eq(appointment_date) }
 
+  describe '#attendee_country' do
+    subject(:attendee_country) { output_document.attendee_country }
+
+    context 'when United Kingdom' do
+      let(:country) { Countries.uk }
+
+      it 'is nil' do
+        expect(attendee_country).to be_nil
+      end
+    end
+
+    context 'with a non-UK address' do
+      let(:country) { Countries.non_uk.sample }
+
+      it 'includes the Country' do
+        expect(attendee_country).to eq(country)
+      end
+    end
+  end
+
   describe '#attendee_address' do
     subject(:attendee_address) { output_document.attendee_address }
 


### PR DESCRIPTION
There is no need to include 'United Kingdom' on address labels when sending the documents. We therefore only include the country if the customer has specified a non-UK address.

@andrewgarner do you think we need more test coverage for the CSV phase?