### PR TITLE
Don't depend on specific postgres `DateStyle`

### DIFF
--- a/app/forms/appointment_summary_browser.rb
+++ b/app/forms/appointment_summary_browser.rb
@@ -20,6 +20,6 @@ class AppointmentSummaryBrowser
   private
 
   def normalise_date(date, default)
-    date.present? ? date : default
+    date.present? ? Time.zone.parse(date) : default
   end
 end

--- a/spec/forms/appointment_summary_browser_spec.rb
+++ b/spec/forms/appointment_summary_browser_spec.rb
@@ -17,5 +17,17 @@ RSpec.describe AppointmentSummaryBrowser do
 
       expect(subject.results).to match_array(present)
     end
+
+    context 'on postgres `DateStyle` iso, mdy servers (travis-ci)' do
+      it 'will not overflow for UK formatted dates' do
+        expect do
+          described_class.new(
+            page: nil,
+            start_date: '15/01/2016',
+            end_date: '16/01/2016'
+          ).results
+        end.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
Prior to this change, the cucumber features were failing in Travis if
the current day falls within a range of dates that could not be parsed
in ISO or MDY specification.