### PR TITLE
Rake tasks for User administration

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,8 @@ class User < ActiveRecord::Base
 
   has_many :appointment_summaries
 
+  scope :admins, -> { where(admin: true).order(:last_name, :first_name) }
+
   def send_devise_notification(notification, *args)
     devise_mailer.send(notification, self, *args).deliver_later
   end

--- a/app/services/user_admin_cli.rb
+++ b/app/services/user_admin_cli.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class UserAdminCli
+  def admins
+    User.admins.map { |u| "#{u.name} <#{u.email}>" }
+  end
+end

--- a/app/services/user_admin_cli.rb
+++ b/app/services/user_admin_cli.rb
@@ -3,4 +3,12 @@ class UserAdminCli
   def admins
     User.admins.map { |u| "#{u.name} <#{u.email}>" }
   end
+
+  def toggle(email)
+    return unless email.present?
+
+    User.find_by(email: email).tap do |u|
+      u&.toggle!(:admin)
+    end
+  end
 end

--- a/lib/tasks/user_admin.rake
+++ b/lib/tasks/user_admin.rake
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+namespace :user do
+  namespace :admin do
+    desc 'Prints a list of administrative users'
+    task list: :environment do
+      admins = UserAdminCli.new.admins
+
+      if admins.empty?
+        puts 'There are no administrative users'
+      else
+        puts admins
+      end
+    end
+  end
+end

--- a/lib/tasks/user_admin.rake
+++ b/lib/tasks/user_admin.rake
@@ -5,11 +5,23 @@ namespace :user do
     task list: :environment do
       admins = UserAdminCli.new.admins
 
+      puts 'Configured Administrators:'
+
       if admins.empty?
         puts 'There are no administrative users'
       else
         puts admins
       end
+    end
+
+    desc 'Toggle a user to / from an administrator'
+    task toggle: :environment do
+      unless email = ENV['EMAIL'] # rubocop:disable Lint/AssignmentInCondition
+        abort 'Usage: bundle exec rake user:admin:toggle EMAIL="someone@example.com"'
+      end
+
+      UserAdminCli.new.toggle(email)
+      Rake::Task['user:admin:list'].invoke
     end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -6,6 +6,10 @@ FactoryGirl.define do
     first_name 'Rick'
     last_name 'Sanchez'
     admin false
+
+    factory :admin do
+      admin true
+    end
   end
 
   factory :appointment_summary do

--- a/spec/services/user_admin_cli_spec.rb
+++ b/spec/services/user_admin_cli_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe UserAdminCli do
+  let!(:admin) { create(:admin, email: 'rick@example.com') }
+  let!(:standard_user) { create(:user) }
+
+  describe '#admins' do
+    it 'returns the names and email addresses of current admins' do
+      expect(subject.admins).to match_array(['Rick Sanchez <rick@example.com>'])
+    end
+  end
+end

--- a/spec/services/user_admin_cli_spec.rb
+++ b/spec/services/user_admin_cli_spec.rb
@@ -10,4 +10,19 @@ RSpec.describe UserAdminCli do
       expect(subject.admins).to match_array(['Rick Sanchez <rick@example.com>'])
     end
   end
+
+  describe '#toggle' do
+    context 'for an existing user' do
+      it 'toggles the `admin` flag' do
+        expect(subject.toggle('rick@example.com')).not_to be_admin
+        expect(subject.toggle('rick@example.com')).to be_admin
+      end
+    end
+
+    context 'for a non-existent user' do
+      it 'returns nil' do
+        expect(subject.toggle('whoops@example.com')).to be_falsey
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds two rake tasks. One for listing existing users with the administrative
flag set and another for toggling the flag on a user specified by the provided
email address.