### PR TITLE
Add missing foreign key

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -111,5 +111,6 @@ ActiveRecord::Schema.define(version: 20160414150822) do
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   add_index "users", ["unlock_token"], name: "index_users_on_unlock_token", unique: true, using: :btree
 
+  add_foreign_key "appointment_summaries_batches", "appointment_summaries"
   add_foreign_key "appointment_summaries_batches", "batches"
 end


### PR DESCRIPTION
Running `rake db:migrate` inferred this relationship.