### PR TITLE
Generate output documents with non-UK countries in uppercase

### DIFF
--- a/app/domain/output_document.rb
+++ b/app/domain/output_document.rb
@@ -22,7 +22,7 @@ class OutputDocument
   end
 
   def attendee_country
-    Countries.uk?(appointment_summary.country) ? nil : appointment_summary.country
+    Countries.uk?(appointment_summary.country) ? nil : appointment_summary.country.upcase
   end
 
   def attendee_address

--- a/spec/domain/output_document_spec.rb
+++ b/spec/domain/output_document_spec.rb
@@ -64,8 +64,8 @@ RSpec.describe OutputDocument do
     context 'with a non-UK address' do
       let(:country) { Countries.non_uk.sample }
 
-      it 'includes the Country' do
-        expect(attendee_country).to eq(country)
+      it 'includes the Country in uppercase' do
+        expect(attendee_country).to eq(country.upcase)
       end
     end
   end
@@ -85,9 +85,8 @@ RSpec.describe OutputDocument do
     context 'with a non-UK address' do
       let(:country) { Countries.non_uk.sample }
 
-      it 'includes the Country' do
-        expect(attendee_address).to eq("Mr Joe Bloggs\nHM Treasury\n1 Horse Guards Road\nWhitehall\n" \
-                                       "Westminster\nGreater London\nSW1A 2HQ\n#{country}")
+      it 'includes the Country in uppercase' do
+        expect(attendee_address).to end_with(country.upcase)
       end
     end
 


### PR DESCRIPTION
This is a Royal Mail requirement for sending international post.