### PR TITLE
Warn on destructive migrations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 gem 'autoprefixer-rails'
 gem 'bootstrap-kaminari-views'
 gem 'bugsnag'
+gem 'deprecated_columns'
 gem 'devise'
 gem 'devise_invitable'
 gem 'devise_zxcvbn'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,8 @@ GEM
       rails (>= 3, < 5)
     database_cleaner (1.4.1)
     debug_inspector (0.0.2)
+    deprecated_columns (0.1.0)
+      rails (>= 4.0)
     devise (3.4.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -302,6 +304,7 @@ DEPENDENCIES
   bugsnag
   cucumber-rails
   database_cleaner
+  deprecated_columns
   devise
   devise_invitable
   devise_zxcvbn


### PR DESCRIPTION
Since we use preloaded dynos we should actively highlight destructive
schema changes. Loading the `deprecated_columns` gem will warn for
migrations with persisted attributes not marked with the
`deprecated_columns` macro.