### PR TITLE
Drop `rvm` stanza

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ env:
   - DATABASE_URL=postgres://postgres@localhost:5432/travis_ci_test
 node_js:
 - '0.10'
-rvm:
-- 2.3.0
 before_install:
 - echo -e "machine github.com\n  login $CI_USER_TOKEN" >> ~/.netrc
 before_script:


### PR DESCRIPTION
When the `rvm` stanza is unspecified, travis will fallback on the
`.ruby-version` specified Ruby. Depending on this behaviour means we
can drop the redundant version information here, since we specify it
canonically in the `.ruby-version` file.