### PR TITLE
[WIP] Tag logs with devise's `current_user`

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require_relative '../../lib/devise_tagged_logging'
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -51,6 +53,9 @@ Rails.application.configure do
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:uuid]
+
+  # Prepend log lines with the `current_user`
+  config.app_middleware.insert_after(Warden::Manager, DeviseTaggedLogging)
 
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)

--- a/lib/devise_tagged_logging.rb
+++ b/lib/devise_tagged_logging.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+class DeviseTaggedLogging
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    if logger.respond_to?(:tagged)
+      logger.tagged(devise_tags(env)) { @app.call(env) }
+    else
+      @app.call(env)
+    end
+  end
+
+  private
+
+  def logger
+    Rails.logger
+  end
+
+  def devise_tags(env)
+    "uid: #{env['warden'].user.try(:id)}"
+  end
+end


### PR DESCRIPTION
This adds `[uid: 1]` prefixes to logging via rails tagged logging. This
is so we can track a user's steps through the application flow to check
if they've been recorded post-interview summaries correctly.

This is done via a rack middleware since using the regular
`config.log_tags` with a `proc` to retrieve information from cookies /
session is too far down the middleware chain, after
`Rails::Rack::Logger` is called. /shrug