### PR TITLE
Improve email reliability by asking for confirmation

### DIFF
--- a/app/controllers/appointment_summaries_controller.rb
+++ b/app/controllers/appointment_summaries_controller.rb
@@ -17,8 +17,13 @@ class AppointmentSummariesController < ApplicationController
     if @appointment_summary.valid?
       @output_document = OutputDocument.new(@appointment_summary)
     else
-      render :new
+      render :email_confirmation
     end
+  end
+
+  def email_confirmation
+    @appointment_summary = AppointmentSummary.new(appointment_summary_params)
+    render :new unless @appointment_summary.valid?
   end
 
   def create

--- a/app/views/appointment_summaries/_preview_form.html.erb
+++ b/app/views/appointment_summaries/_preview_form.html.erb
@@ -2,12 +2,11 @@
   url: local_assigns.fetch(:url),
   method: local_assigns.fetch(:method) { :post } do |f| %>
 
-  <% (AppointmentSummary.columns.map(&:name) - %w(id created_at updated_at user_id)).each do |field| %>
+  <% AppointmentSummary.editable_column_names.each do |field| %>
     <%= f.hidden_field field %>
   <% end %>
 
   <%= f.submit local_assigns.fetch(:submit_button_text),
     class: (%w(btn btn-lg) | Array(local_assigns[:submit_button_classes])),
     data: { disable_with: 'Please wait...' } %>
-
 <% end %>

--- a/app/views/appointment_summaries/email_confirmation.html.erb
+++ b/app/views/appointment_summaries/email_confirmation.html.erb
@@ -1,0 +1,27 @@
+<div class="page-header">
+  <h1>Make sure this is right</h1>
+</div>
+
+
+<%= form_for @appointment_summary,
+             url: preview_appointment_summaries_path,
+             method: :post do |f| %>
+  <%= error_messages_for(@appointment_summary) %>
+
+  <% AppointmentSummary.editable_column_names.each do |field| %>
+    <% next if field == 'email' %>
+    <%= f.hidden_field field %>
+  <% end %>
+
+  <div class="form-group">
+    <%= f.label :email %>
+    <%= f.text_field :email, class: %w(form-control t-email input-md-3) %>
+  </div>
+
+  <%= f.submit "Yes - this is the customer's email address",
+               class: 'btn btn-lg btn-success t-confirm',
+               data: { disable_with: 'Please wait...' } %>
+
+<% end %>
+
+<p class="help-block">If the customer's email address is wrong, just change it above</p>

--- a/app/views/appointment_summaries/new.html.erb
+++ b/app/views/appointment_summaries/new.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @appointment_summary, url: preview_appointment_summaries_path do |f| %>
+<%= form_for @appointment_summary, url: email_confirmation_appointment_summaries_path do |f| %>
   <div class="page-header">
     <h1><%= title 'New appointment summary' %></h1>
   </div>
@@ -464,7 +464,7 @@
     </div>
 
     <p>
-      <%= f.submit 'Preview', class: %w(btn-success t-submit btn-lg) %>
+      <%= f.submit 'Next', class: %w(btn-success t-submit btn-lg) %>
     </p>
 
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
 
   resources :appointment_summaries, only: %i(new create) do
     post :preview, on: :collection
+    post :email_confirmation, on: :collection
   end
 
   scope path: 'styleguide', controller: 'styleguide' do

--- a/features/email_confirmation.feature
+++ b/features/email_confirmation.feature
@@ -1,0 +1,16 @@
+Feature: Email confirmation
+  As Pension Wise
+  We want the guider to perform a secondary check on the customers email address they have entered
+  To improve the accuracy of the email and ensure the customer is notified
+
+  Scenario: Confirm email address
+    Given a guider has submitted the customer's details in an appointment summary
+    When they confirm the email address is correctly entered
+    And they confirm the preview of the appointment
+    Then the confirmed email address is saved
+
+  Scenario: Edit incorrect email during email confirmation
+    Given a guider has submitted the customer's details in an appointment summary
+    When they correct the email address during the confirmation step
+    And they confirm the preview of the appointment
+    Then the confirmed email address is saved

--- a/features/step_definitions/back_from_preview_steps.rb
+++ b/features/step_definitions/back_from_preview_steps.rb
@@ -6,6 +6,9 @@ Given(/^appointment details are captured$/) do
   page.load
   page.fill_in(@appointment_summary)
   page.submit.click
+
+  email_confirmation_page = EmailConfirmationPage.new
+  email_confirmation_page.confirm.click
 end
 
 Given(/^I'm on the preview page$/) do

--- a/features/step_definitions/email_confirmation_steps.rb
+++ b/features/step_definitions/email_confirmation_steps.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+Given(/^a guider has submitted the customer's details in an appointment summary$/) do
+  @appointment_summary = fixture(:populated_appointment_summary)
+  @email = @appointment_summary.email
+  page = AppointmentSummaryPage.new
+  page.load
+  page.fill_in(@appointment_summary)
+  page.submit.click
+end
+
+When(/^they confirm the email address is correctly entered$/) do
+  email_confirmation_page = EmailConfirmationPage.new
+  email_confirmation_page.confirm.click
+end
+
+Then(/^they confirm the preview of the appointment$/) do
+  preview_page = PreviewPage.new
+  preview_page.confirm.click
+end
+
+Then(/^the confirmed email address is saved$/) do
+  expect(AppointmentSummary.last.email).to eq(@email)
+end
+
+When(/^they correct the email address during the confirmation step$/) do
+  @email = 'updated@email.com'
+  email_confirmation_page = EmailConfirmationPage.new
+  email_confirmation_page.email.set @email
+  email_confirmation_page.confirm.click
+end

--- a/features/step_definitions/preview_record_of_guidance_contents_steps.rb
+++ b/features/step_definitions/preview_record_of_guidance_contents_steps.rb
@@ -4,6 +4,9 @@ When(/^I preview (?:their|a) record of guidance$/) do
   page.load
   page.fill_in(@appointment_summary)
   page.submit.click
+
+  email_confirmation_page = EmailConfirmationPage.new
+  email_confirmation_page.confirm.click
 end
 
 Then(/^the sections that the preview includes should be \(in order\):$/) do |table|

--- a/features/step_definitions/record_of_guidance_contents_steps.rb
+++ b/features/step_definitions/record_of_guidance_contents_steps.rb
@@ -5,6 +5,9 @@ When(/^we send (?:them their|a) record of guidance$/) do
   appointment_summary_page.fill_in(@appointment_summary)
   appointment_summary_page.submit.click
 
+  email_confirmation_page = EmailConfirmationPage.new
+  email_confirmation_page.confirm.click
+
   preview_page = PreviewPage.new
   preview_page.confirm.click
 

--- a/features/step_definitions/record_of_guidance_steps.rb
+++ b/features/step_definitions/record_of_guidance_steps.rb
@@ -27,6 +27,9 @@ When(/^I create their record of guidance$/) do
   appointment_summary_page.fill_in(@appointment_summary)
   appointment_summary_page.submit.click
 
+  email_confirmation_page = EmailConfirmationPage.new
+  email_confirmation_page.confirm.click
+
   preview_page = PreviewPage.new
   preview_page.confirm.click
 end

--- a/features/support/pages/email_confirmation_page.rb
+++ b/features/support/pages/email_confirmation_page.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+class EmailConfirmationPage < SitePrism::Page
+  set_url_matcher %r{/appointment_summaries/email_confirmation}
+
+  element :email, '.t-email'
+  element :confirm, '.t-confirm'
+end


### PR DESCRIPTION
Based on:
 
https://designnotes.blog.gov.uk/2015/09/15/make-sure-this-is-right-a-new-email-confirmation-pattern/ 

to improve percentage of correctly entered email addresses