### PR TITLE
Send Ineligible template if customer is ineligible

### DIFF
--- a/app/jobs/notify_via_email.rb
+++ b/app/jobs/notify_via_email.rb
@@ -12,7 +12,7 @@ class NotifyViaEmail < ActiveJob::Base
     response = notify(
       service_id: config.service_id,
       secret_id: config.secret_id,
-      notification: notification(appointment_summary, config)
+      notification: notification(appointment_summary, template_id(appointment_summary, config))
     )
 
     appointment_summary.update_attributes(notification_id: response.id)
@@ -23,10 +23,10 @@ class NotifyViaEmail < ActiveJob::Base
     client.send_email(notification.to_json)
   end
 
-  def notification(appointment_summary, config)
+  def notification(appointment_summary, template_id)
     {
       to: appointment_summary.email,
-      template: config.appointment_summary_template_id,
+      template: template_id,
       personalisation: {
         reference_number: appointment_summary.reference_number,
         title: appointment_summary.title,
@@ -35,5 +35,9 @@ class NotifyViaEmail < ActiveJob::Base
         date_of_appointment: appointment_summary.date_of_appointment.to_s(:pw_date_long)
       }
     }
+  end
+
+  def template_id(appointment_summary, config)
+    appointment_summary.eligible_for_guidance? ? config.appointment_summary_template_id : config.ineligible_template_id
   end
 end

--- a/config/initializers/notify.rb
+++ b/config/initializers/notify.rb
@@ -3,4 +3,5 @@ Rails.configuration.x.notify.tap do |notify|
   notify.service_id = ENV['NOTIFY_SERVICE_ID']
   notify.secret_id = ENV['NOTIFY_SECRET_ID']
   notify.appointment_summary_template_id = ENV['APPOINTMENT_SUMMARY_TEMPLATE_ID']
+  notify.ineligible_template_id = ENV['INELIGIBLE_TEMPLATE_ID']
 end

--- a/spec/jobs/notify_via_email_spec.rb
+++ b/spec/jobs/notify_via_email_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe NotifyViaEmail do
       :config,
       service_id: 'service',
       secret_id: 'secret',
-      appointment_summary_template_id: 'template'
+      appointment_summary_template_id: 'template',
+      ineligible_template_id: 'ineligible_template'
     )
   end
   let(:client) { double('Notifications::Client', send_email: response) }
@@ -18,22 +19,46 @@ RSpec.describe NotifyViaEmail do
     allow(Notifications::Client).to receive(:new).and_return(client)
   end
 
-  it 'sends a email notification' do
-    expect(client).to receive(:send_email).with(
-      {
-        to: appointment_summary.email,
-        template: 'template',
-        personalisation: {
-          reference_number: appointment_summary.reference_number,
-          title: appointment_summary.title,
-          last_name: appointment_summary.last_name,
-          guider_name: appointment_summary.guider_name,
-          date_of_appointment: appointment_summary.date_of_appointment.to_s(:pw_date_long)
-        }
-      }.to_json
-    )
+  context 'when the customer has a DC pension' do
+    it 'sends a standard email notification' do
+      expect(client).to receive(:send_email).with(
+        {
+          to: appointment_summary.email,
+          template: 'template',
+          personalisation: {
+            reference_number: appointment_summary.reference_number,
+            title: appointment_summary.title,
+            last_name: appointment_summary.last_name,
+            guider_name: appointment_summary.guider_name,
+            date_of_appointment: appointment_summary.date_of_appointment.to_s(:pw_date_long)
+          }
+        }.to_json
+      )
 
-    described_class.perform_now(appointment_summary, config: config)
+      described_class.perform_now(appointment_summary, config: config)
+    end
+  end
+
+  context 'when the customer does not have a DC pension' do
+    let(:appointment_summary) { create(:appointment_summary, has_defined_contribution_pension: 'no') }
+
+    it 'sends an ineligible email notification' do
+      expect(client).to receive(:send_email).with(
+        {
+          to: appointment_summary.email,
+          template: 'ineligible_template',
+          personalisation: {
+            reference_number: appointment_summary.reference_number,
+            title: appointment_summary.title,
+            last_name: appointment_summary.last_name,
+            guider_name: appointment_summary.guider_name,
+            date_of_appointment: appointment_summary.date_of_appointment.to_s(:pw_date_long)
+          }
+        }.to_json
+      )
+
+      described_class.perform_now(appointment_summary, config: config)
+    end
   end
 
   it 'stores the notification id' do


### PR DESCRIPTION
Previously guiders could only send notifications 
to ineligible customers via post

This release will correspond with an update to guider notes, allowing them to send ineligible notifications via email if the customer opts into digital.