### PR TITLE
Regenerate summary document

### DIFF
--- a/app/controllers/appointment_summaries_controller.rb
+++ b/app/controllers/appointment_summaries_controller.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 class AppointmentSummariesController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: :index
+  before_action :authenticate_team_leader!, only: :index
+
+  def index
+    form_params = { search_string: params.dig(:appointment_summary_finder, :search_string) }
+
+    @appointment_form = AppointmentSummaryFinder.new(form_params)
+  end
 
   def new
     prepopulated_fields = { guider_name: current_user.first_name,
@@ -47,5 +54,11 @@ class AppointmentSummariesController < ApplicationController
 
   def appointment_summary_params
     params.require(:appointment_summary).permit(AppointmentSummary.editable_column_names)
+  end
+
+  def authenticate_team_leader!
+    authenticate_user!
+
+    redirect_to :root unless current_user.team_leader?
   end
 end

--- a/app/forms/appointment_summary_browser.rb
+++ b/app/forms/appointment_summary_browser.rb
@@ -14,9 +14,7 @@ class AppointmentSummaryBrowser
   def results
     text_filter(
       date_filter(
-        AppointmentSummary
-          .includes(:user)
-          .order(date_of_appointment: :desc)
+        AppointmentSummary.order(date_of_appointment: :desc)
       )
     )
   end

--- a/app/forms/appointment_summary_finder.rb
+++ b/app/forms/appointment_summary_finder.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+class AppointmentSummaryFinder
+  include ActiveModel::Model
+
+  attr_accessor :search_string
+
+  def initialize(search_string:)
+    @search_string = search_string
+  end
+
+  def results
+    return [] if search_string.blank?
+
+    AppointmentSummary
+      .where(reference_number: search_string)
+      .order(:date_of_appointment, :created_at)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,11 +24,11 @@ class User < ActiveRecord::Base
   end
 
   def admin?
-    role == ADMIN
+    [ADMIN].include?(role)
   end
 
   def team_leader?
-    role == TEAM_LEADER
+    [ADMIN, TEAM_LEADER].include?(role)
   end
 
   def toggle_role(role_to_toggle)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,11 +1,19 @@
 # frozen_string_literal: true
 class User < ActiveRecord::Base
+  deprecated_columns :admin
+
+  class UnableToSetRole < StandardError; end
+
+  ADMIN = 'admin'
+  TEAM_LEADER = 'team_leader'
+
   devise :database_authenticatable, :confirmable, :invitable, :lockable, :timeoutable, :trackable,
          :validatable, :zxcvbnable, :recoverable
 
   has_many :appointment_summaries
 
-  scope :admins, -> { where(admin: true).order(:last_name, :first_name) }
+  scope :admins, -> { where(role: ADMIN).order(:last_name, :first_name) }
+  scope :team_leaders, -> { where(role: TEAM_LEADER).order(:last_name, :first_name) }
 
   def send_devise_notification(notification, *args)
     devise_mailer.send(notification, self, *args).deliver_later
@@ -13,5 +21,19 @@ class User < ActiveRecord::Base
 
   def name
     [first_name, last_name].join(' ').strip
+  end
+
+  def admin?
+    role == ADMIN
+  end
+
+  def team_leader?
+    role == TEAM_LEADER
+  end
+
+  def toggle_role(role_to_toggle)
+    raise(UnableToSetRole, "User has existing role: #{role}") unless ['', role_to_toggle].include?(role)
+
+    update_attributes(role: role.present? ? '' : role_to_toggle)
   end
 end

--- a/app/services/user_admin_cli.rb
+++ b/app/services/user_admin_cli.rb
@@ -4,11 +4,25 @@ class UserAdminCli
     User.admins.map { |u| "#{u.name} <#{u.email}>" }
   end
 
-  def toggle(email)
+  def team_leaders
+    User.team_leaders.map { |u| "#{u.name} <#{u.email}>" }
+  end
+
+  def toggle_admin(email)
+    toggle(email, User::ADMIN)
+  end
+
+  def toggle_team_leader(email)
+    toggle(email, User::TEAM_LEADER)
+  end
+
+  private
+
+  def toggle(email, role)
     return unless email.present?
 
     User.find_by(email: email).tap do |u|
-      u&.toggle!(:admin)
+      u&.toggle_role(role)
     end
   end
 end

--- a/app/views/appointment_summaries/index.html.erb
+++ b/app/views/appointment_summaries/index.html.erb
@@ -1,0 +1,42 @@
+<h1><%= title 'Appointment Summaries' %></h1>
+
+<div class="well">
+  <%= form_for @appointment_form, url: appointment_summaries_path, method: :get, html: { class: 'inline form-inline' } do |f| %>
+    <div class="form-group">
+      <%= f.label :search_string, 'Search', class: 'inline' %>
+      <%= f.text_field :search_string, class: 'form-control t-search', placeholder: 'Surname or Reference' %>
+    </div>
+    <%= f.submit 'Search', class: 'btn btn-default t-search-button' %>
+  <% end %>
+</div>
+
+<table class="table table-striped table-bordered">
+  <thead>
+    <tr class="table-header">
+      <th scope="col">Reference</th>
+      <th scope="col">Guider</th>
+      <th scope="col">Customer</th>
+      <th scope="col">Appointment<br>Date</th>
+      <th scope="col">Generated<br>At</th>
+      <th scope="col">Requested<br>Digital</th>
+      <th scope="col">Email</th>
+      <th scope="col"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @appointment_form.results.each do |summary| %>
+      <tr class="t-appointment">
+        <td class="t-reference-number"><%= summary.reference_number %></td>
+        <td><%= summary.guider_name %></td>
+        <td><%= "#{summary.title} #{summary.first_name} #{summary.last_name}" %></td>
+        <td><%= summary.date_of_appointment.to_s(:gov_uk) %></td>
+        <td><%= summary.created_at.to_s(:govuk_date) %></td>
+        <td><%= summary.requested_digital ? 'Yes' : 'No' %></td>
+        <td><%= summary.email %></td>
+        <td>
+          <%= link_to 'Regenerate', new_appointment_summary_path(appointment_summary: summary.attributes), class: 't-regenerate' %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,6 +26,19 @@
       <%= link_to 'Change password', edit_user_registration_path %>
     </div>
   <% end %>
+
+  <% if current_user.team_leader? %>
+    <% content_for :navbar_items do %>
+      <li>
+        <%= link_to 'Regenerate', appointment_summaries_path %>
+      </li>
+      <% if current_user.admin? %>
+        <li>
+          <%= link_to 'Reporting', admin_appointment_summaries_path %>
+        </li>
+      <% end %>
+    <% end %>
+  <% end %>
 <% end %>
 
 <% content_for(:content) do %>

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -5,6 +5,8 @@ Date::DATE_FORMATS[:pw_date_long] = '%A, %-d %B %Y'
 
 Date::DATE_FORMATS[:gov_uk] = '%-d %B %Y'
 
+Time::DATE_FORMATS[:govuk_date] = '%-I:%M%P, %-e %B %Y'
+
 default = { default: '%d/%m/%Y' }
 Time::DATE_FORMATS.merge!(default)
 Date::DATE_FORMATS.merge!(default)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :appointment_summaries, only: %i(new create) do
+  resources :appointment_summaries, only: %i(index new create) do
     post :preview, on: :collection
     post :email_confirmation, on: :collection
   end

--- a/db/migrate/20160901121801_add_role_to_user.rb
+++ b/db/migrate/20160901121801_add_role_to_user.rb
@@ -1,0 +1,7 @@
+class AddRoleToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :role, :string, default: '', null: false
+    execute "UPDATE users SET role = '#{User::ADMIN}' where admin"
+    remove_column :users, :admin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160721095104) do
+ActiveRecord::Schema.define(version: 20160901121801) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,9 +76,9 @@ ActiveRecord::Schema.define(version: 20160721095104) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "",    null: false
+    t.string   "email",                  default: "", null: false
     t.string   "encrypted_password",     default: ""
-    t.integer  "sign_in_count",          default: 0,     null: false
+    t.integer  "sign_in_count",          default: 0,  null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.inet     "current_sign_in_ip"
@@ -87,7 +87,7 @@ ActiveRecord::Schema.define(version: 20160721095104) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string   "unconfirmed_email"
-    t.integer  "failed_attempts",        default: 0,     null: false
+    t.integer  "failed_attempts",        default: 0,  null: false
     t.string   "unlock_token"
     t.datetime "locked_at"
     t.datetime "created_at"
@@ -105,7 +105,7 @@ ActiveRecord::Schema.define(version: 20160721095104) do
     t.string   "last_name"
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
-    t.boolean  "admin",                  default: false, null: false
+    t.string   "role",                   default: "", null: false
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree

--- a/features/regenerate_summary_document.feature
+++ b/features/regenerate_summary_document.feature
@@ -1,0 +1,12 @@
+Feature: Regenerate Summary Document
+  As a user
+  I want to regenerate a customers summary document
+  So that I can resend it when the customer has not received the original
+
+  @unauthenticated
+  Scenario: Regenerate a summary document
+    Given I log in to regenerate a summary document
+    When I enter a customer reference number
+    And I select the matched record to regenerate
+    Then I am able to edit the customers details
+    And I can regenerate the customers summary document

--- a/features/step_definitions/appointment_summary_steps.rb
+++ b/features/step_definitions/appointment_summary_steps.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 Given(/^I am logged in as a Pension Wise Administrator$/) do
-  @administrator = create(:user, admin: true).tap(&:confirm!)
+  @administrator = create(:admin).tap(&:confirm!)
 
   page = UserSignInPage.new
   page.login(@administrator)

--- a/features/step_definitions/regenerate_summary_ocument_steps.rb
+++ b/features/step_definitions/regenerate_summary_ocument_steps.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+Given(/^I log in to regenerate a summary document$/) do
+  @appointment_summary = create(:appointment_summary)
+  @user = create(:team_leader).tap(&:confirm!)
+
+  page = UserSignInPage.new
+  page.login(@user)
+end
+
+When(/^I enter a customer reference number$/) do
+  @page = AppointmentSummariesPage.new
+  @page.load
+  @page.search(@appointment_summary.reference_number)
+end
+
+When(/^I select the matched record to regenerate$/) do
+  appointment = @page.appointments.first
+  expect(appointment.reference_number.text).to eq(@appointment_summary.reference_number)
+  appointment.regenerate_button.click
+end
+
+Then(/^I am able to edit the customers details$/) do
+  @page = AppointmentSummaryPage.new
+  expect(@page).to be_displayed
+end
+
+Then(/^I can regenerate the customers summary document$/) do
+  @page.submit.click
+  expect(@page).not_to be_displayed
+end

--- a/features/support/pages/appointment_summaries_page.rb
+++ b/features/support/pages/appointment_summaries_page.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class AppointmentSummariesPage < SitePrism::Page
+  set_url '/appointment_summaries'
+
+  sections :appointments, '.t-appointment' do
+    element :reference_number, '.t-reference-number'
+    element :regenerate_button, '.t-regenerate'
+  end
+
+  element :search_input, '.t-search'
+  element :search_button, '.t-search-button'
+
+  def search(reference_number)
+    search_input.set(reference_number)
+    search_button.click
+  end
+end

--- a/features/support/pages/appointment_summary_page.rb
+++ b/features/support/pages/appointment_summary_page.rb
@@ -6,6 +6,7 @@ class AppointmentSummaryPage < SitePrism::Page
   extend SitePrism::RadioButtonContainer
 
   set_url '/appointment_summaries/new'
+  set_url_matcher %r{/appointment_summaries/new}
 
   element :title, '.t-title'
   element :first_name, '.t-first-name'

--- a/lib/tasks/user_admin.rake
+++ b/lib/tasks/user_admin.rake
@@ -20,8 +20,33 @@ namespace :user do
         abort 'Usage: bundle exec rake user:admin:toggle EMAIL="someone@example.com"'
       end
 
-      UserAdminCli.new.toggle(email)
+      UserAdminCli.new.toggle_admin(email)
       Rake::Task['user:admin:list'].invoke
+    end
+  end
+
+  namespace :team_leader do
+    desc 'Prints a list of teamn leader users'
+    task list: :environment do
+      team_leaders = UserAdminCli.new.team_leaders
+
+      puts 'Configured Team Leaders:'
+
+      if team_leaders.empty?
+        puts 'There are no administrative users'
+      else
+        puts team_leaders
+      end
+    end
+
+    desc 'Toggle a user to / from a team leader'
+    task toggle: :environment do
+      unless email = ENV['EMAIL'] # rubocop:disable Lint/AssignmentInCondition
+        abort 'Usage: bundle exec rake user:team_leader:toggle EMAIL="someone@example.com"'
+      end
+
+      UserAdminCli.new.toggle_team_leader(email)
+      Rake::Task['user:team_leader:list'].invoke
     end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -5,10 +5,14 @@ FactoryGirl.define do
     password 'password'
     first_name 'Rick'
     last_name 'Sanchez'
-    admin false
+    role ''
 
     factory :admin do
-      admin true
+      role User::ADMIN
+    end
+
+    factory :team_leader do
+      role User::TEAM_LEADER
     end
   end
 

--- a/spec/services/user_admin_cli_spec.rb
+++ b/spec/services/user_admin_cli_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 
 RSpec.describe UserAdminCli do
   let!(:admin) { create(:admin, email: 'rick@example.com') }
+  let!(:team_leaders) { create(:team_leader, email: 'sanchez@example.com') }
   let!(:standard_user) { create(:user) }
 
   describe '#admins' do
@@ -11,17 +12,54 @@ RSpec.describe UserAdminCli do
     end
   end
 
-  describe '#toggle' do
+  describe '#team_leaders' do
+    it 'returns the names and email addresses of current team leaders' do
+      expect(subject.team_leaders).to match_array(['Rick Sanchez <sanchez@example.com>'])
+    end
+  end
+
+  describe '#toggle_admin' do
     context 'for an existing user' do
-      it 'toggles the `admin` flag' do
-        expect(subject.toggle('rick@example.com')).not_to be_admin
-        expect(subject.toggle('rick@example.com')).to be_admin
+      it 'toggles the `admin` role' do
+        expect(subject.toggle_admin('rick@example.com')).not_to be_admin
+        expect(subject.toggle_admin('rick@example.com')).to be_admin
+      end
+
+      context 'who already has another role' do
+        it 'raises an error' do
+          expect do
+            expect(subject.toggle_admin('sanchez@example.com'))
+          end.to raise_error(User::UnableToSetRole)
+        end
       end
     end
 
     context 'for a non-existent user' do
       it 'returns nil' do
-        expect(subject.toggle('whoops@example.com')).to be_falsey
+        expect(subject.toggle_admin('whoops@example.com')).to be_falsey
+      end
+    end
+  end
+
+  describe '#toggle_team_leader' do
+    context 'for an existing user' do
+      it 'toggles the `team_leader` role' do
+        expect(subject.toggle_team_leader('sanchez@example.com')).not_to be_team_leader
+        expect(subject.toggle_team_leader('sanchez@example.com')).to be_team_leader
+      end
+
+      context 'who already has another role' do
+        it 'raises an error' do
+          expect do
+            expect(subject.toggle_team_leader('rick@example.com'))
+          end.to raise_error(User::UnableToSetRole)
+        end
+      end
+    end
+
+    context 'for a non-existent user' do
+      it 'returns nil' do
+        expect(subject.toggle_admin('whoops@example.com')).to be_falsey
       end
     end
   end


### PR DESCRIPTION
Allow Team leaders to regenerate a summary document. This creates a new summary document record with allow any of the details to be corrected if required.

The PR also removes the admin flag and replaces it with a role, at this stage users can only have a single role at any one time.