### PR TITLE
Allow resend with the same email address

### DIFF
--- a/app/controllers/admin/appointment_summaries_controller.rb
+++ b/app/controllers/admin/appointment_summaries_controller.rb
@@ -47,6 +47,7 @@ module Admin
     def appointment_summary_params
       params.require(:appointment_summary)
             .permit(:email)
+            .merge(notification_id: nil)
     end
   end
 end

--- a/app/jobs/notify_via_email.rb
+++ b/app/jobs/notify_via_email.rb
@@ -2,12 +2,18 @@
 require 'notifications/client'
 
 class NotifyViaEmail < ActiveJob::Base
-  class AttemptingToResendNotification < StandardError; end
+  class AttemptingToResendNotification < StandardError
+    ERROR_ATTRIBUTES = %w(id email first_name last_name notification_id).freeze
+
+    def initialize(appointment_summary)
+      super(appointment_summary.attributes.slice(*ERROR_ATTRIBUTES).inspect)
+    end
+  end
 
   queue_as :default
 
   def perform(appointment_summary, config: Rails.configuration.x.notify)
-    raise AttemptingToResendNotification, appointment_summary.inspect if appointment_summary.notification_id.present?
+    raise AttemptingToResendNotification, appointment_summary if appointment_summary.notification_id.present?
 
     response = notify(
       service_id: config.service_id,

--- a/app/models/appointment_summary.rb
+++ b/app/models/appointment_summary.rb
@@ -79,8 +79,6 @@ class AppointmentSummary < ActiveRecord::Base
   validates :number_of_previous_appointments, inclusion: { in: 0..3 }
   validates :email, format: EMAIL_REGEXP
 
-  before_save :reset_notification_id!
-
   def self.editable_column_names
     column_names - %w(id created_at updated_at user_id notification_id)
   end
@@ -105,9 +103,5 @@ class AppointmentSummary < ActiveRecord::Base
 
   def uk_address?
     Countries.uk?(country)
-  end
-
-  def reset_notification_id!
-    self.notification_id = '' if email_changed?
   end
 end

--- a/app/models/appointment_summary.rb
+++ b/app/models/appointment_summary.rb
@@ -5,7 +5,7 @@ require 'uri'
 class AppointmentSummary < ActiveRecord::Base
   DIGITAL_BY_DEFAULT_START_DATE = Date.new(2016, 6, 21)
   EMAIL_REGEXP = Regexp.union(
-    /\A[^\s][^@\s]+@([^@\.\s]+\.)+[^@\.\s]+[^\s]\z/,
+    /\A[^\@\s]+@[^\@\.\s]+(\.[^\@\.\s]+)+$/,
     /\A\z/
   )
 

--- a/spec/controllers/admin/appointment_summaries_controller_spec.rb
+++ b/spec/controllers/admin/appointment_summaries_controller_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe Admin::AppointmentSummariesController, type: :controller do
+  let(:email) { 'guider@example.com' }
+  let(:password) { 'pensionwise' }
+  let(:user) { User.create(email: email, password: password, role: 'admin').tap(&:confirm!) }
+  let(:appointment_summary) { create(:appointment_summary, notification_id: '123', requested_digital: true) }
+
+  describe '#update' do
+    subject { response }
+
+    context 'when not authenticated' do
+      before do
+        put :update, id: appointment_summary.id
+      end
+
+      it { is_expected.to redirect_to(controller: 'devise/sessions', action: :new) }
+    end
+
+    context 'when authenticated' do
+      before do
+        allow(NotifyViaEmail).to receive(:perform_later)
+        sign_in user
+        put :update, id: appointment_summary.id, appointment_summary: { email: email }
+        appointment_summary.reload
+      end
+
+      context 'when email has changed and is valid' do
+        let(:email) { 'good-email@test.com' }
+
+        it 'updates the email address' do
+          expect(appointment_summary.email).to eq(email)
+        end
+
+        it 'resets the notification_id' do
+          expect(appointment_summary.notification_id).to be_blank
+        end
+
+        it 'enqueues the NotifyViaEmail job' do
+          expect(NotifyViaEmail).to have_received(:perform_later).with(appointment_summary)
+        end
+
+        context 'when the customer has not requested a digital summary document' do
+          let(:appointment_summary) { create(:appointment_summary, notification_id: '123', requested_digital: false) }
+
+          it 'does not enqueue the NotifyViaEmail job' do
+            expect(NotifyViaEmail).not_to have_received(:perform_later)
+          end
+        end
+      end
+
+      context 'when email has not changed' do
+        let(:email) { appointment_summary.email }
+
+        it 'resets the notification_id' do
+          expect(appointment_summary.notification_id).to be_blank
+        end
+
+        it 'enqueues the NotifyViaEmail job' do
+          expect(NotifyViaEmail).to have_received(:perform_later).with(appointment_summary)
+        end
+      end
+
+      context 'when email is not valid' do
+        let(:email) { 'bad email@test.com' }
+
+        it 'does not resets the notification_id' do
+          expect(appointment_summary.notification_id).not_to be_blank
+        end
+
+        it 'does not enqueue the NotifyViaEmail job' do
+          expect(NotifyViaEmail).not_to have_received(:perform_later)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/appointment_summary_spec.rb
+++ b/spec/models/appointment_summary_spec.rb
@@ -169,27 +169,4 @@ RSpec.describe AppointmentSummary, type: :model do
       it { is_expected.to eq(appointment_summaries[2, 3]) }
     end
   end
-
-  context 'notification ID' do
-    subject { create(:appointment_summary, requested_digital: true, email: 'test@test.com') }
-    before { subject.update(notification_id: '123') }
-
-    it 'resets the notification ID if the email changes' do
-      expect do
-        subject.update(email: 'new@test.com')
-      end.to change { subject.notification_id }.from('123').to('')
-    end
-
-    it 'does not reset the notification ID if the email address stays the same' do
-      expect do
-        subject.update(email: subject.email)
-      end.not_to change { subject.notification_id }
-    end
-
-    it 'does not reset the notification ID if fields other than the email address are changed' do
-      expect do
-        subject.update(last_name: 'new_name')
-      end.not_to change { subject.notification_id }
-    end
-  end
 end


### PR DESCRIPTION
* Don't raise NotificationAlreadySent error when trying to resend notification without changing the email address
* Cleaner message for NotificationAlreadySent - only return useful variables 
* Update email regex - use the regex used by notify