### PR TITLE
Update email regex

### DIFF
--- a/app/models/appointment_summary.rb
+++ b/app/models/appointment_summary.rb
@@ -4,8 +4,9 @@ require 'uri'
 
 class AppointmentSummary < ActiveRecord::Base
   DIGITAL_BY_DEFAULT_START_DATE = Date.new(2016, 6, 21)
+  # bassed off: https://github.com/alphagov/notifications-utils/blob/master/notifications_utils/recipients.py#L22
   EMAIL_REGEXP = Regexp.union(
-    /\A[^\@\s]+@[^\@\.\s]+(\.[^\@\.\s]+)+$/,
+    /\A([^";@\s\.]+\.)*[^";@\s\.]+@([^";@\s\.]+\.)+[a-z]{2,10}\z/,
     /\A\z/
   )
 

--- a/spec/models/appointment_summary_spec.rb
+++ b/spec/models/appointment_summary_spec.rb
@@ -59,6 +59,12 @@ RSpec.describe AppointmentSummary, type: :model do
     it { is_expected.not_to allow_value('fred@no-extension').for(:email) }
     it { is_expected.not_to allow_value('  fred@spaced.com  ').for(:email) }
     it { is_expected.not_to allow_value('a  fred@spaced.com').for(:email) }
+    it { is_expected.not_to allow_value('a..fred@spaced.com').for(:email) }
+    it { is_expected.not_to allow_value('fred@spaced..com').for(:email) }
+    it { is_expected.to allow_value('a.fred@spaced.com').for(:email) }
+    it { is_expected.not_to allow_value('fr@ed@spaced..com').for(:email) }
+    it { is_expected.not_to allow_value('"fred"@spaced.com').for(:email) }
+    it { is_expected.not_to allow_value('fred;jones@spaced.com').for(:email) }
     it { is_expected.to allow_value('').for(:email) }
   end
 


### PR DESCRIPTION
Keep it inline with the Notify regex to avoid predictable
errors when sending the email across.

Difference to the notify regex:

* block '..' in regex - notify has a secondary check
* block spaces in email address