### PR TITLE
Always require signin permission

### DIFF
--- a/app/controllers/admin/appointment_summaries_controller.rb
+++ b/app/controllers/admin/appointment_summaries_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 module Admin
   class AppointmentSummariesController < ::ApplicationController
+    before_action :require_signin_permission! # this can't be in ApplicationController due to Gaffe gem
     before_action :authenticate_as_analyst!
 
     def index

--- a/app/controllers/appointment_summaries_controller.rb
+++ b/app/controllers/appointment_summaries_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class AppointmentSummariesController < ApplicationController
-  before_action :authenticate_user!, except: :index
+  before_action :require_signin_permission! # this can't be in ApplicationController due to Gaffe gem
   before_action :authenticate_as_team_leader!, only: :index
 
   def index

--- a/spec/controllers/admin/appointment_summaries_controller_spec.rb
+++ b/spec/controllers/admin/appointment_summaries_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Admin::AppointmentSummariesController, type: :controller do
     subject { response }
 
     context 'when not authenticated' do
-      let(:user) { User.create(email: email) }
+      let(:user) { create(:user, email: email) }
 
       before do
         put :update, id: appointment_summary.id
@@ -23,7 +23,7 @@ RSpec.describe Admin::AppointmentSummariesController, type: :controller do
     end
 
     context 'when authenticated' do
-      let(:user) { User.create(email: email, permissions: ['analyst']) }
+      let(:user) { create(:user, email: email, permissions: %w(signin analyst)) }
 
       before do
         allow(NotifyViaEmail).to receive(:perform_later)


### PR DESCRIPTION
Remotely removing access to the application works
by removing the 'signin' permission from the users.

That means that a user with 'team_leader' permission
but with access blocked for the application would
still have been able to access the 'team_leader' sections
of the application.