### PR TITLE
Create summary document activity in TAP

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'retriable'
 gem 'sass-rails', '~> 5.0'
 gem 'sidekiq'
 gem 'sinatra', require: nil # Sidekiq UI
+gem 'telephone_appointments'
 gem 'uglifier', '>= 1.3.0'
 gem 'uk_postcode'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -297,6 +297,8 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    telephone_appointments (0.1.1)
+      activesupport (>= 4, < 5.1)
     thor (0.19.4)
     thread_safe (0.3.5)
     tilt (2.0.5)
@@ -363,6 +365,7 @@ DEPENDENCIES
   sidekiq
   sinatra
   site_prism
+  telephone_appointments
   uglifier (>= 1.3.0)
   uk_postcode
   web-console (~> 2.0)

--- a/app/controllers/appointment_summaries_controller.rb
+++ b/app/controllers/appointment_summaries_controller.rb
@@ -34,7 +34,8 @@ class AppointmentSummariesController < ApplicationController
   end
 
   def create
-    @appointment_summary = AppointmentSummary.create!(appointment_summary_params.merge(user: current_user))
+    @appointment_summary = AppointmentSummary.create!(appointment_summary_params)
+    CreateTapActivity.perform_later(@appointment_summary, current_user)
     NotifyViaEmail.perform_later(@appointment_summary) if @appointment_summary.can_be_emailed?
 
     respond_to do |format|
@@ -61,7 +62,10 @@ class AppointmentSummariesController < ApplicationController
   private
 
   def appointment_summary_params
-    params.require(:appointment_summary).permit(AppointmentSummary.editable_column_names)
+    params
+      .require(:appointment_summary)
+      .permit(AppointmentSummary.editable_column_names)
+      .merge(user: current_user)
   end
 
   def ajax_response_paths(appointment_summary)

--- a/app/jobs/create_tap_activity.rb
+++ b/app/jobs/create_tap_activity.rb
@@ -1,0 +1,23 @@
+require 'notifications/client'
+
+class CreateTapActivity < ApplicationJob
+  class UnableToCreateSummaryDocumentActivity < StandardError; end
+
+  rescue_from(CreateTapActivity::UnableToCreateSummaryDocumentActivity) do |exception|
+    Bugsnag.notify(exception)
+  end
+
+  queue_as :default
+
+  def perform(appointment_summary, owner)
+    telephone_appointment = TelephoneAppointments::SummaryDocumentActivity.new(
+      appointment_id: appointment_summary.reference_number,
+      owner_uid: owner.uid,
+      delivery_method: appointment_summary.requested_digital ? 'digital' : 'postal'
+    )
+
+    return if telephone_appointment.save
+
+    raise UnableToCreateSummaryDocumentActivity, "Errors: #{telephone_appointment.errors.inspect}"
+  end
+end

--- a/app/views/appointment_summaries/done.html.erb
+++ b/app/views/appointment_summaries/done.html.erb
@@ -2,5 +2,3 @@
 
 <p>Appointment details have been saved. A Pension Wise Summary Document will be printed and dispatched to the
   customer shortly.</p>
-
-<p style='padding-top: 1em'><%= link_to 'Generate another', root_path, class: %w(btn-success btn-lg) %></p>

--- a/spec/jobs/create_tap_activity_spec.rb
+++ b/spec/jobs/create_tap_activity_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe CreateTapActivity do
+  let(:owner) { double(:owner, uid: 'aaaaaa') }
+  before do
+    allow(TelephoneAppointments::SummaryDocumentActivity).to receive(:new).and_return(summary_document_activity)
+  end
+
+  context 'when a posted summary document is requested' do
+    let(:appointment_summary) { double(:appointment_summary, reference_number: '1234', requested_digital: false) }
+    let(:summary_document_activity) { double(:summary_document_activity, save: true) }
+
+    it 'creates a new summary document activity' do
+      expect(TelephoneAppointments::SummaryDocumentActivity).to receive(:new).with(
+        appointment_id: '1234',
+        owner_uid: 'aaaaaa',
+        delivery_method: 'postal'
+      )
+      expect(summary_document_activity).to receive(:save)
+
+      described_class.perform_now(appointment_summary, owner)
+    end
+  end
+
+  context 'when an emailed summary document is requested' do
+    let(:appointment_summary) { double(:appointment_summary, reference_number: '1234', requested_digital: true) }
+    let(:summary_document_activity) { double(:summary_document_activity, save: true) }
+
+    it 'creates a new summary document activity' do
+      expect(TelephoneAppointments::SummaryDocumentActivity).to receive(:new).with(
+        appointment_id: '1234',
+        owner_uid: 'aaaaaa',
+        delivery_method: 'digital'
+      )
+      expect(summary_document_activity).to receive(:save)
+
+      described_class.perform_now(appointment_summary, owner)
+    end
+  end
+
+  context 'when the summary document fails to save' do
+    let(:appointment_summary) { double(:appointment_summary, reference_number: '1234', requested_digital: false) }
+    let(:summary_document_activity) do
+      double(:summary_document_activity, save: false, errors: { 'owner_id' => 'can be black' })
+    end
+
+    it 'reports an error via bugsnag' do
+      expect(Bugsnag).to receive(:notify).with(an_instance_of(described_class::UnableToCreateSummaryDocumentActivity))
+      described_class.perform_now(appointment_summary, owner)
+    end
+  end
+end


### PR DESCRIPTION
Once a summary document has been created trigger
the appropriate activity to be created in TAP.

the following variables will need to be set:

```ruby
TELEPHONE_APPOINTMENTS_API_BEARER_TOKEN
TELEPHONE_APPOINTMENTS_API_URI
```

**Pending** Fix build pack