### PR TITLE
Include the appointment reference for debugging

### DIFF
--- a/app/jobs/create_tap_activity.rb
+++ b/app/jobs/create_tap_activity.rb
@@ -18,6 +18,9 @@ class CreateTapActivity < ApplicationJob
 
     return if telephone_appointment.save
 
-    raise UnableToCreateSummaryDocumentActivity, "Errors: #{telephone_appointment.errors.inspect}"
+    raise UnableToCreateSummaryDocumentActivity, <<~MESSAGE
+      Appointment: #{appointment_summary.reference_number}
+      Errors: #{telephone_appointment.errors.inspect}
+    MESSAGE
   end
 end

--- a/spec/jobs/create_tap_activity_spec.rb
+++ b/spec/jobs/create_tap_activity_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe CreateTapActivity do
   context 'when the summary document fails to save' do
     let(:appointment_summary) { double(:appointment_summary, reference_number: '1234', requested_digital: false) }
     let(:summary_document_activity) do
-      double(:summary_document_activity, save: false, errors: { 'owner_id' => 'can be black' })
+      double(:summary_document_activity, save: false, errors: { 'owner_id' => "can't be blank" })
     end
 
     it 'reports an error via bugsnag' do


### PR DESCRIPTION
We currently have no way of knowing which actual appointment this refers to
so when these occur in production we are at a loss.