### PR TITLE
Ensure appointments are summarised via TAP

### DIFF
--- a/app/controllers/appointment_summaries_controller.rb
+++ b/app/controllers/appointment_summaries_controller.rb
@@ -11,12 +11,16 @@ class AppointmentSummariesController < ApplicationController
   end
 
   def new
-    prepopulated_fields = { guider_name: current_user.first_name,
-                            date_of_appointment: Time.zone.today }
+    if summarisable?
+      prepopulated_fields = { guider_name: current_user.first_name,
+                              date_of_appointment: Time.zone.today }
 
-    prepopulated_fields.merge!(appointment_summary_params.to_h) if params.include?(:appointment_summary)
+      prepopulated_fields.merge!(appointment_summary_params.to_h) if params.include?(:appointment_summary)
 
-    @appointment_summary = AppointmentSummary.new(prepopulated_fields)
+      @appointment_summary = AppointmentSummary.new(prepopulated_fields)
+    else
+      render :summarise_via_tap
+    end
   end
 
   def preview
@@ -60,6 +64,10 @@ class AppointmentSummariesController < ApplicationController
   end
 
   private
+
+  def summarisable?
+    current_user.team_leader? || params.key?(:appointment_summary)
+  end
 
   def appointment_summary_params
     params

--- a/app/views/appointment_summaries/summarise_via_tap.html.erb
+++ b/app/views/appointment_summaries/summarise_via_tap.html.erb
@@ -1,0 +1,6 @@
+<div class="page-header">
+  <h1>Summarise via the Telephone Appointment Planner</h1>
+</div>
+
+<p class="help-block">Appointments must be summarised via the Telephone
+Appointment Planner, once the appointment's status is updated.</p>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :user do
     sequence(:email) { |n| "user#{n}@example.com" }
     name 'Rick Sanchez'
-    permissions ['signin']
+    permissions %w(signin team_leader)
   end
 
   factory :appointment_summary do


### PR DESCRIPTION
We should stop guiders from landing directly here and summarising
appointments by entering the TAP reference. When this happens, they
circumvent the status checks that occur in TAP and thus the outbound
webhook to create the TAP activity fails upon creation.

This change throws up a warning screen to the guider (team leaders are
still permitted) telling them to summarise the appointment from TAP.

![screen shot 2017-02-16 at 15 46 53](https://cloud.githubusercontent.com/assets/41963/23029010/f9ce4c4e-f460-11e6-9194-40b1682c62ce.png)
