### PR TITLE
Poll for notify delivery statuses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,3 +32,8 @@ Style/RescueModifier:
 
 Style/EmptyMethod:
   Enabled: false
+
+Metrics/AbcSize:
+  Exclude:
+    - spec/**/*
+

--- a/app/jobs/notify_delivery_check.rb
+++ b/app/jobs/notify_delivery_check.rb
@@ -1,0 +1,7 @@
+class NotifyDeliveryCheck < ActiveJob::Base
+  queue_as :default
+
+  def perform(appointment_summary)
+    NotifyDelivery.new.call(appointment_summary)
+  end
+end

--- a/app/services/notify_delivery.rb
+++ b/app/services/notify_delivery.rb
@@ -1,0 +1,37 @@
+require 'notifications/client'
+
+class NotifyDelivery
+  def initialize(client = Notifications::Client.new(ENV['NOTIFY_SECRET_ID']))
+    @client = client
+  end
+
+  def call(appointment_summary)
+    response = client.get_notification(appointment_summary.notification_id)
+
+    process_response(response, appointment_summary)
+  rescue Notifications::Client::RequestError
+    appointment_summary.stop_checking!
+  end
+
+  private
+
+  def process_response(response, appointment_summary)
+    appointment_summary.update_attributes(
+      notify_completed_at: response.completed_at,
+      notify_status: map_status(response)
+    )
+  end
+
+  def map_status(response)
+    case response.status
+    when 'delivered'
+      response.status
+    when /-failure\Z/
+      'failed'
+    else
+      'pending'
+    end
+  end
+
+  attr_reader :client
+end

--- a/app/services/notify_delivery_checker.rb
+++ b/app/services/notify_delivery_checker.rb
@@ -1,0 +1,7 @@
+class NotifyDeliveryChecker
+  def call
+    AppointmentSummary.needing_notify_delivery_check.each do |as|
+      NotifyDeliveryCheck.perform_later(as)
+    end
+  end
+end

--- a/db/migrate/20170222151348_add_notify_delivery_to_appointment_summaries.rb
+++ b/db/migrate/20170222151348_add_notify_delivery_to_appointment_summaries.rb
@@ -1,0 +1,6 @@
+class AddNotifyDeliveryToAppointmentSummaries < ActiveRecord::Migration[5.0]
+  def change
+    add_column :appointment_summaries, :notify_completed_at, :datetime, null: true
+    add_column :appointment_summaries, :notify_status, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161207154853) do
+ActiveRecord::Schema.define(version: 20170222151348) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -67,6 +67,8 @@ ActiveRecord::Schema.define(version: 20161207154853) do
     t.boolean  "retirement_income_unspecified",                    default: false,            null: false
     t.boolean  "retirement_income_defined_benefit",                default: false,            null: false
     t.boolean  "supplementary_pension_transfers",                  default: false
+    t.datetime "notify_completed_at"
+    t.integer  "notify_status",                                    default: 0,                null: false
     t.index ["user_id"], name: "index_appointment_summaries_on_user_id", using: :btree
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 FactoryGirl.define do
   factory :user do
     sequence(:email) { |n| "user#{n}@example.com" }
@@ -27,5 +29,10 @@ FactoryGirl.define do
     number_of_previous_appointments 0
     requested_digital false
     email 'joe@bloggs.com'
+
+    factory :notify_delivered_appointment_summary do
+      requested_digital true
+      notification_id { SecureRandom.uuid }
+    end
   end
 end

--- a/spec/jobs/notify_delivery_check_spec.rb
+++ b/spec/jobs/notify_delivery_check_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe NotifyDeliveryCheck, '#perform' do
+  let(:appointment_summary) { double }
+  let(:service) { instance_double(NotifyDelivery) }
+
+  it 'calls the service with the given appointment summary' do
+    expect(NotifyDelivery).to receive(:new) { service }
+    expect(service).to receive(:call).with(appointment_summary)
+
+    described_class.new.perform(appointment_summary)
+  end
+end

--- a/spec/services/notify_delivery_checker_spec.rb
+++ b/spec/services/notify_delivery_checker_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe NotifyDeliveryChecker do
+  include ActiveJob::TestHelper
+
+  before do
+    # due for checking
+    @due = create(:notify_delivered_appointment_summary)
+    # already marked completed
+    create(:notify_delivered_appointment_summary, notify_completed_at: Time.zone.now)
+    # outside the two day window
+    create(:notify_delivered_appointment_summary, created_at: 3.days.ago)
+    # without a notification ID from the notify service
+    create(:notify_delivered_appointment_summary, notification_id: '')
+  end
+
+  it 'schedules the correct summaries for checking' do
+    assert_enqueued_with job: NotifyDeliveryCheck, args: Array(@due) do
+      NotifyDeliveryChecker.new.call
+    end
+  end
+end

--- a/spec/services/notify_delivery_spec.rb
+++ b/spec/services/notify_delivery_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe NotifyDelivery, '#call' do
+  let(:appointment_summary) { create(:notify_delivered_appointment_summary) }
+  let(:client) { instance_double(Notifications::Client) }
+
+  subject { described_class.new(client).call(appointment_summary) }
+
+  context 'when the notification failed' do
+    before do
+      allow(client).to receive(:get_notification).and_return(
+        double(completed_at: nil, status: 'permanent-failure')
+      )
+    end
+
+    it 'marks the summary as failed' do
+      subject
+
+      expect(appointment_summary).to be_failed
+    end
+  end
+
+  context 'when the notification was delivered' do
+    before do
+      allow(client).to receive(:get_notification).and_return(
+        double(completed_at: Time.zone.now, status: 'delivered')
+      )
+    end
+
+    it 'marks the summary as delivered' do
+      subject
+
+      expect(appointment_summary.notify_completed_at).to be_present
+      expect(appointment_summary).to be_delivered
+    end
+  end
+
+  context 'when the notification is not found' do
+    before do
+      allow(client).to receive(:get_notification).and_raise(
+        Notifications::Client::RequestError.new(
+          double(code: 404, body: '{"errors":[]}')
+        )
+      )
+    end
+
+    it 'marks the summary so it is not checked again' do
+      subject
+
+      expect(appointment_summary.notify_completed_at).to be_present
+      expect(appointment_summary).to be_ignoring
+    end
+  end
+end


### PR DESCRIPTION
We need to poll for notify email delivery statuses to ensure we remain
deliverable at all times. Unfortunately notify does not supply webhooks
so we have to poll for the statuses instead.

A summary will be included for polling when it's less than two days old,
has a notify supplied ID and its `notify_completed_at` timestamp is
absent. When notify deems itself 'done' with our notification whether
due to a permanent failure or delivery it will supply us with the
`completed_at` timestamp that we use to mark the summary for exclusion
next time around.

This will need to be scheduled `rails runner 'NotifyDeliveryChecker.new.call'`.