### PR TITLE
Ping TAP when notify tells us a delivery failed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'retriable'
 gem 'sass-rails', '~> 5.0'
 gem 'sidekiq'
 gem 'sinatra', require: nil # Sidekiq UI
-gem 'telephone_appointments'
+gem 'telephone_appointments', github: 'guidance-guarantee-programme/telephone_appointments'
 gem 'uglifier', '>= 1.3.0'
 gem 'uk_postcode'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,13 @@ GIT
   specs:
     princely (2.0.2)
 
+GIT
+  remote: https://github.com/guidance-guarantee-programme/telephone_appointments.git
+  revision: 2d5e9382fd17c3d71c6f5658896ac161037613c6
+  specs:
+    telephone_appointments (0.2.0)
+      activesupport (>= 4, < 5.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -292,8 +299,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    telephone_appointments (0.1.1)
-      activesupport (>= 4, < 5.1)
     thor (0.19.4)
     thread_safe (0.3.5)
     tilt (2.0.5)
@@ -360,7 +365,7 @@ DEPENDENCIES
   sidekiq
   sinatra
   site_prism
-  telephone_appointments
+  telephone_appointments!
   uglifier (>= 1.3.0)
   uk_postcode
   web-console (~> 2.0)

--- a/spec/services/notify_delivery_spec.rb
+++ b/spec/services/notify_delivery_spec.rb
@@ -20,6 +20,24 @@ RSpec.describe NotifyDelivery, '#call' do
     end
   end
 
+  context 'when the notification failed and notify returned a `completed_at` timestamp' do
+    let(:activity) { double(save: true) }
+
+    before do
+      allow(client).to receive(:get_notification).and_return(
+        double(completed_at: Time.zone.now, status: 'permanent-failure')
+      )
+
+      allow(TelephoneAppointments::DroppedSummaryDocumentActivity).to receive(:new) { activity }
+    end
+
+    it 'notifies TAP with an activity entry' do
+      subject
+
+      expect(activity).to have_received(:save)
+    end
+  end
+
   context 'when the notification was delivered' do
     before do
       allow(client).to receive(:get_notification).and_return(


### PR DESCRIPTION
Ping TAP to create an activity when GOVUK notify tells us a summary
document delivery failed to deliver.

I've pinned to the unreleased GitHub gem for the timebeing while I wait for
ownership of the gem on rubygems.org.