### PR TITLE
Ensure we pass the correct reference to the API

### DIFF
--- a/app/services/notify_delivery.rb
+++ b/app/services/notify_delivery.rb
@@ -27,7 +27,9 @@ class NotifyDelivery
   def notify_tap(appointment_summary)
     return unless appointment_summary.failed? && appointment_summary.notify_completed_at?
 
-    TelephoneAppointments::DroppedSummaryDocumentActivity.new(appointment_summary.to_param).save
+    TelephoneAppointments::DroppedSummaryDocumentActivity.new(
+      appointment_summary.reference_number
+    ).save
   end
 
   def map_status(response)

--- a/spec/services/notify_delivery_spec.rb
+++ b/spec/services/notify_delivery_spec.rb
@@ -27,11 +27,13 @@ RSpec.describe NotifyDelivery, '#call' do
       allow(client).to receive(:get_notification).and_return(
         double(completed_at: Time.zone.now, status: 'permanent-failure')
       )
-
-      allow(TelephoneAppointments::DroppedSummaryDocumentActivity).to receive(:new) { activity }
     end
 
     it 'notifies TAP with an activity entry' do
+      expect(
+        TelephoneAppointments::DroppedSummaryDocumentActivity
+      ).to receive(:new).with(appointment_summary.reference_number) { activity }
+
       subject
 
       expect(activity).to have_received(:save)


### PR DESCRIPTION
We need to pass the original booking reference to the API so we can
reconcile correctly between the two records.