### PR TITLE
Check for notify deliveries every minute

### DIFF
--- a/app/jobs/notify_deliveries_check.rb
+++ b/app/jobs/notify_deliveries_check.rb
@@ -1,0 +1,7 @@
+class NotifyDeliveriesCheck < ActiveJob::Base
+  queue_as :default
+
+  def perform
+    NotifyDeliveryChecker.new.call
+  end
+end

--- a/lib/tasks/scheduling.rake
+++ b/lib/tasks/scheduling.rake
@@ -1,0 +1,10 @@
+namespace :scheduling do
+  desc 'Schedule a job every minute in the next ten minutes'
+  task notify_checks: :environment do
+    NotifyDeliveriesCheck.perform_later
+
+    (1..9).each do |n|
+      NotifyDeliveriesCheck.set(wait_until: n.minutes.from_now).perform_later
+    end
+  end
+end


### PR DESCRIPTION
This is a bit of a hack to workaround the heroku scheduler's limit on
running jobs at most once every ten minutes. When this newly introduced
rake task runs it will first schedule a check to run immediately, then
another 9 checks, covering each subsequent minute.