### PR TITLE
Permit regeneration of TAP appointment summaries

### DIFF
--- a/app/controllers/appointment_summaries_controller.rb
+++ b/app/controllers/appointment_summaries_controller.rb
@@ -2,6 +2,7 @@
 class AppointmentSummariesController < ApplicationController
   before_action :require_signin_permission! # this can't be in ApplicationController due to Gaffe gem
   before_action :authenticate_as_team_leader!, only: :index
+  before_action :load_summary, only: %i(new email_confirmation update)
 
   def index
     @appointment_form = AppointmentSummaryFinder.new(
@@ -12,12 +13,7 @@ class AppointmentSummariesController < ApplicationController
 
   def new
     if summarisable?
-      prepopulated_fields = { guider_name: current_user.first_name,
-                              date_of_appointment: Time.zone.today }
-
-      prepopulated_fields.merge!(appointment_summary_params.to_h) if params.include?(:appointment_summary)
-
-      @appointment_summary = AppointmentSummary.new(prepopulated_fields)
+      @appointment_summary.assign_attributes(appointment_summary_params)
     else
       render :summarise_via_tap
     end
@@ -33,19 +29,26 @@ class AppointmentSummariesController < ApplicationController
   end
 
   def email_confirmation
-    @appointment_summary = AppointmentSummary.new(appointment_summary_params)
+    @appointment_summary.assign_attributes(appointment_summary_params)
+
     render :new unless @appointment_summary.valid?
   end
 
   def create
     @appointment_summary = AppointmentSummary.create!(appointment_summary_params)
-    CreateTapActivity.perform_later(@appointment_summary, current_user)
-    NotifyViaEmail.perform_later(@appointment_summary) if @appointment_summary.can_be_emailed?
+    send_notifications(@appointment_summary)
 
     respond_to do |format|
       format.html { redirect_to done_appointment_summaries_path }
       format.json { render json: ajax_response_paths(@appointment_summary) }
     end
+  end
+
+  def update
+    @appointment_summary.update!(appointment_summary_params)
+    send_notifications(@appointment_summary)
+
+    redirect_to done_appointment_summaries_path
   end
 
   def show
@@ -64,6 +67,17 @@ class AppointmentSummariesController < ApplicationController
   end
 
   private
+
+  def load_summary
+    @appointment_summary = AppointmentSummary.find_or_initialize_by(
+      reference_number: params.dig(:appointment_summary, :reference_number)
+    )
+  end
+
+  def send_notifications(appointment_summary)
+    CreateTapActivity.perform_later(appointment_summary, current_user)
+    NotifyViaEmail.perform_later(appointment_summary) if appointment_summary.can_be_emailed?
+  end
 
   def summarisable?
     params.key?(:appointment_summary)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   mount GovukAdminTemplate::Engine, at: '/style-guide'
   mount Sidekiq::Web => '/sidekiq', constraints: AuthenticatedUser.new
 
-  resources :appointment_summaries, only: %i(index new create show) do
+  resources :appointment_summaries, only: %i(index new create update show) do
     collection do
       get :creating
       get :done

--- a/features/support/pages/appointment_summary_page.rb
+++ b/features/support/pages/appointment_summary_page.rb
@@ -91,7 +91,7 @@ class AppointmentSummaryPage < SitePrism::Page
 
     {}.tap do |params|
       params_from_tap.each do |param|
-        params["appointment_summary[#{param}]"] = appointment_summary[param.to_s]
+        params["appointment_summary[#{param}]"] = appointment_summary[param]
       end
     end
   end

--- a/spec/features/tap_summary_document_generation_spec.rb
+++ b/spec/features/tap_summary_document_generation_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+require_relative '../../features/support/pages/appointment_summary_page'
+
+RSpec.feature 'Appointment Summaries' do
+  scenario 'Regenerating an existing appointment summary' do
+    given_an_existing_appointment_summary
+    when_the_guider_attempts_to_regenerate_the_summary
+    then_the_existing_appointment_summary_is_displayed
+    and_the_details_provided_by_tap_are_displayed
+    when_the_guider_modifies_the_summary
+    then_the_existing_summary_is_updated
+  end
+
+  def given_an_existing_appointment_summary
+    @summary = create(:appointment_summary, reference_number: '123456')
+  end
+
+  def when_the_guider_attempts_to_regenerate_the_summary
+    @page = AppointmentSummaryPage.new.tap do |page|
+      page.load(
+        appointment_type: 'standard',
+        date_of_appointment: '2017-02-02',
+        email: 'george@example.com',
+        first_name: 'George',
+        last_name: 'Georgeson',
+        guider_name: 'Jan Janson',
+        number_of_previous_appointments: '0',
+        reference_number: '123456'
+      )
+    end
+  end
+
+  def then_the_existing_appointment_summary_is_displayed
+    # check only a sample of existing attributes
+    expect(@page.address_line_1.value).to eq(@summary.address_line_1)
+    expect(@page.postcode.value).to eq(@summary.postcode)
+  end
+
+  def and_the_details_provided_by_tap_are_displayed
+    expect(@page.reference_number.value).to eq('123456')
+    expect(@page.appointment_type_standard).to be_checked
+    expect(@page.date_of_appointment.value).to eq('2017-02-02')
+    expect(@page.email.value).to eq('george@example.com')
+    expect(@page.first_name.value).to eq('George')
+    expect(@page.last_name.value).to eq('Georgeson')
+    expect(@page.guider_name.value).to eq('Jan Janson')
+  end
+
+  def when_the_guider_modifies_the_summary
+    @page.address_line_1.set('5 Grange Hill')
+
+    @page.submit.click
+  end
+
+  def then_the_existing_summary_is_updated
+    expect(@summary.reload.address_line_1).to eq('5 Grange Hill')
+  end
+end


### PR DESCRIPTION
Lets guiders modify existing appointment summaries when the original
appointment record is updated in TAP. The previously persisted summary
details are bound to the form and are modifiable. When validated /
persisted we ping TAP to create another activity entry and if necessary
email the customer.