### PR TITLE
Don't guard against resending of digital summary

### DIFF
--- a/app/jobs/notify_via_email.rb
+++ b/app/jobs/notify_via_email.rb
@@ -12,8 +12,6 @@ class NotifyViaEmail < ApplicationJob
   queue_as :default
 
   def perform(appointment_summary, config: Rails.configuration.x.notify)
-    raise AttemptingToResendNotification, appointment_summary if appointment_summary.notification_id.present?
-
     payload  = notification(appointment_summary, template_id(appointment_summary, config))
     response = Notifications::Client.new(config.secret_id).send_email(payload)
 

--- a/spec/jobs/notify_via_email_spec.rb
+++ b/spec/jobs/notify_via_email_spec.rb
@@ -65,11 +65,4 @@ RSpec.describe NotifyViaEmail do
     appointment_summary.reload
     expect(appointment_summary.notification_id).to eq('12345')
   end
-
-  it 'raises an error if a notification has already been sent' do
-    appointment_summary.notification_id = 'already send'
-    expect do
-      described_class.perform_now(appointment_summary, config: config)
-    end.to raise_error(described_class::AttemptingToResendNotification)
-  end
 end


### PR DESCRIPTION
Now we can reissue the summaries we don't need to guard against
resending them.