### PR TITLE
Ensure we poll for delivery status on resends

### DIFF
--- a/app/jobs/notify_via_email.rb
+++ b/app/jobs/notify_via_email.rb
@@ -15,7 +15,11 @@ class NotifyViaEmail < ApplicationJob
     payload  = notification(appointment_summary, template_id(appointment_summary, config))
     response = Notifications::Client.new(config.secret_id).send_email(payload)
 
-    appointment_summary.update_attributes(notification_id: response.id)
+    appointment_summary.update_attributes(
+      notification_id: response.id,
+      notify_completed_at: nil,
+      notify_status: :pending
+    )
   end
 
   private

--- a/spec/jobs/notify_via_email_spec.rb
+++ b/spec/jobs/notify_via_email_spec.rb
@@ -60,9 +60,19 @@ RSpec.describe NotifyViaEmail do
     end
   end
 
-  it 'stores the notification id' do
-    described_class.perform_now(appointment_summary, config: config)
-    appointment_summary.reload
-    expect(appointment_summary.notification_id).to eq('12345')
+  context 'when regenerating' do
+    let(:appointment_summary) do
+      create(:appointment_summary, notify_completed_at: '2017-02-02 13:00', notify_status: :delivered)
+    end
+
+    it 'ensures the record is polled for notify delivery status' do
+      described_class.perform_now(appointment_summary, config: config)
+
+      expect(appointment_summary.reload).to have_attributes(
+        notification_id: '12345',
+        notify_completed_at: nil,
+        notify_status: 'pending'
+      )
+    end
   end
 end


### PR DESCRIPTION
We need to reset the timestamp and status to ensure once we have
reissued an appointment summary digitally via notify that we then poll
at the scheduled intervals for its delivery status. Prior to this
change, we were not resetting those markers against the record so it was
being skipped when determining which records to poll.