### PR TITLE
Ensure previews are displayed when regenerating

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ services:
 cache:
   bundler: true
   directories:
+  - '.downloads'
   - node_modules
   - tmp/cache/assets/test
   - vendor/assets/bower_components
@@ -18,8 +19,11 @@ node_js:
 before_install:
 - echo -e "machine github.com\n  login $CI_USER_TOKEN" >> ~/.netrc
 before_script:
+- '[ -d .downloads ] || mkdir .downloads'
+- '(cd .downloads; [ -d prince-9.0r5-linux-amd64-static ] || curl -s http://www.princexml.com/download/prince-9.0r5-linux-amd64-static.tar.gz | tar xzf -)'
+- echo $PWD | ./.downloads/prince-9.0r5-linux-amd64-static/install.sh
 - npm install
-- "./bin/rake db:setup RAILS_ENV=test"
+- './bin/rake db:setup RAILS_ENV=test'
 notifications:
   slack:
     secure: YSz3iC+QIFKS108cIAc+bmImetKRRb0fij9g7skft+Ug9Err4JDMGo0fX+2vHL9XOk+tx5wWJZjy/HSpHd5kMAw8+ASXCQf3mqLyC9GR2zgxxb6Xs1I0Hc1yuzYHv+6zrEvbS5P+zf2Fz3mj1rEaK3Yf7wmw/Rags1X42R9jPcc=

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,10 @@ gem 'uglifier', '>= 1.3.0'
 gem 'uk_postcode'
 
 group :development, :test do
+  gem 'database_rewinder'
   gem 'launchy'
+  gem 'phantomjs-binaries'
+  gem 'poltergeist'
   gem 'pry-byebug'
   gem 'rspec-rails'
   gem 'scss-lint'

--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ group :development, :test do
   gem 'poltergeist'
   gem 'pry-byebug'
   gem 'rspec-rails'
-  gem 'scss-lint'
+  gem 'scss_lint', require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,9 +278,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    scss-lint (0.38.0)
-      rainbow (~> 2.0)
-      sass (~> 3.4.1)
+    scss_lint (0.52.0)
+      rake (>= 0.9, < 13)
+      sass (~> 3.4.20)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
     sidekiq (4.2.7)
@@ -369,7 +369,7 @@ DEPENDENCIES
   rspec-rails
   rubocop
   sass-rails (~> 5.0)
-  scss-lint
+  scss_lint
   shoulda-matchers
   sidekiq
   sinatra

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    cliver (0.3.2)
     coderay (1.1.1)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
@@ -98,6 +99,7 @@ GEM
       railties (>= 3, < 5.1)
     cucumber-wire (0.0.1)
     database_cleaner (1.5.3)
+    database_rewinder (0.8.0)
     debug_inspector (0.0.2)
     deprecated_columns (0.1.1)
       rails (>= 4.0)
@@ -111,6 +113,7 @@ GEM
       railties (>= 3.0.0)
     faraday (0.10.0)
       multipart-post (>= 1.2, < 3)
+    ffi (1.9.18)
     foreman (0.82.0)
       thor (~> 0.19.1)
     gaffe (1.2.0)
@@ -187,7 +190,13 @@ GEM
     parser (2.3.3.1)
       ast (~> 2.2)
     pg (0.19.0)
+    phantomjs-binaries (2.1.1.1)
+      sys-uname (= 0.9.0)
     plek (1.12.0)
+    poltergeist (1.13.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -292,6 +301,8 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    sys-uname (0.9.0)
+      ffi (>= 1.0.0)
     telephone_appointments (0.2.1)
       activesupport (>= 4, < 5.1)
     thor (0.19.4)
@@ -328,6 +339,7 @@ DEPENDENCIES
   bugsnag
   cucumber-rails
   database_cleaner
+  database_rewinder
   deprecated_columns
   factory_girl_rails
   faraday
@@ -344,7 +356,9 @@ DEPENDENCIES
   notifications-ruby-client
   output-templates (~> 4.4.5)!
   pg
+  phantomjs-binaries
   plek
+  poltergeist
   princely!
   pry-byebug
   puma
@@ -369,4 +383,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.14.5
+   1.14.6

--- a/app/controllers/appointment_summaries_controller.rb
+++ b/app/controllers/appointment_summaries_controller.rb
@@ -2,7 +2,7 @@
 class AppointmentSummariesController < ApplicationController
   before_action :require_signin_permission! # this can't be in ApplicationController due to Gaffe gem
   before_action :authenticate_as_team_leader!, only: :index
-  before_action :load_summary, only: %i(new email_confirmation update)
+  before_action :load_summary, only: %i(new email_confirmation update preview)
 
   def index
     @appointment_form = AppointmentSummaryFinder.new(
@@ -20,7 +20,8 @@ class AppointmentSummariesController < ApplicationController
   end
 
   def preview
-    @appointment_summary = AppointmentSummary.new(appointment_summary_params)
+    @appointment_summary.assign_attributes(appointment_summary_params)
+
     if @appointment_summary.valid?
       @output_document = OutputDocument.new(@appointment_summary)
     else

--- a/app/views/appointment_summaries/_preview_form.html.erb
+++ b/app/views/appointment_summaries/_preview_form.html.erb
@@ -1,6 +1,12 @@
-<%= form_for local_assigns.fetch(:appointment_summary),
-  url: local_assigns.fetch(:url),
-  method: local_assigns.fetch(:method) { :post } do |f| %>
+<%
+  options = {}
+
+  if local_assigns[:url]
+    options[:url]    = local_assigns[:url]
+    options[:method] = local_assigns.fetch(:method) { :post }
+  end
+%>
+<%= form_for local_assigns.fetch(:appointment_summary), options do |f| %>
 
   <% AppointmentSummary.editable_column_names.each do |field| %>
     <%= f.hidden_field field %>

--- a/app/views/appointment_summaries/new.html.erb
+++ b/app/views/appointment_summaries/new.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @appointment_summary, url: preview_appointment_summaries_path do |f| %>
+<%= form_for @appointment_summary, url: preview_appointment_summaries_path, method: :post do |f| %>
   <div class="page-header">
     <h1><%= title 'New telephone appointment summary' %></h1>
   </div>

--- a/app/views/appointment_summaries/preview.html.erb
+++ b/app/views/appointment_summaries/preview.html.erb
@@ -20,7 +20,7 @@
       <%=
         submit_button_classes = %w(btn-success t-confirm)
         submit_button_classes << 'js-save-and-open' unless @appointment_summary.requested_digital?
-        render 'preview_form', url: appointment_summaries_path, appointment_summary: @appointment_summary,
+        render 'preview_form', appointment_summary: @appointment_summary,
                submit_button_text: 'Submit', submit_button_classes: submit_button_classes
       %>
     </div>
@@ -28,10 +28,17 @@
 </div>
 
 <script>
+  <%
+    path = if @appointment_summary.persisted?
+             appointment_summary_path(@appointment_summary, format: :json)
+           else
+             appointment_summaries_path(format: :json)
+           end
+  %>
   $(".js-save-and-open").click(function(e){
     var popupWindow = window.open('<%= creating_appointment_summaries_path %>');
 
-    $.post('<%= appointment_summaries_path(format: 'json') %>', $(this.form).serialize())
+    $.post('<%= path %>', $(this.form).serialize())
       .done(function(data) {
         popupWindow.location = data.pdf_path;
         window.location = data.done_path;

--- a/features/support/pages/done_page.rb
+++ b/features/support/pages/done_page.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+class DonePage < SitePrism::Page
+  set_url_matcher %r{/appointment_summaries/done}
+end

--- a/spec/features/tap_summary_document_generation_spec.rb
+++ b/spec/features/tap_summary_document_generation_spec.rb
@@ -1,13 +1,14 @@
 require 'rails_helper'
-require_relative '../../features/support/pages/appointment_summary_page'
 
-RSpec.feature 'Appointment Summaries' do
+RSpec.feature 'Appointment Summaries', js: true do
   scenario 'Regenerating an existing appointment summary' do
     given_an_existing_appointment_summary
     when_the_guider_attempts_to_regenerate_the_summary
     then_the_existing_appointment_summary_is_displayed
     and_the_details_provided_by_tap_are_displayed
     when_the_guider_modifies_the_summary
+    then_the_preview_is_displayed
+    when_the_guider_confirms_the_preview
     then_the_existing_summary_is_updated
   end
 
@@ -52,7 +53,19 @@ RSpec.feature 'Appointment Summaries' do
     @page.submit.click
   end
 
+  def then_the_preview_is_displayed
+    @page = PreviewPage.new
+    expect(@page).to be_displayed
+  end
+
+  def when_the_guider_confirms_the_preview
+    @page.confirm.click
+  end
+
   def then_the_existing_summary_is_updated
+    @page = DonePage.new
+    expect(@page).to be_displayed
+
     expect(@summary.reload.address_line_1).to eq('5 Grange Hill')
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,6 +3,11 @@ ENV['RAILS_ENV'] ||= 'test'
 require 'spec_helper'
 require_relative '../config/environment'
 require 'rspec/rails'
+require 'database_rewinder'
+
+require_relative '../features/support/pages/done_page'
+require_relative '../features/support/pages/preview_page'
+require_relative '../features/support/pages/appointment_summary_page'
 
 ActiveRecord::Migration.maintain_test_schema!
 Dir[File.join(File.dirname(__FILE__), 'support', '**', '*.rb')].each { |f| require f }
@@ -13,7 +18,6 @@ RSpec.configure do |config|
 
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
   config.infer_spec_type_from_file_location!
-  config.use_transactional_fixtures = true
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/support/database_rewinder.rb
+++ b/spec/support/database_rewinder.rb
@@ -1,0 +1,7 @@
+RSpec.configure do |config|
+  config.use_transactional_fixtures = false
+
+  config.before(:suite) { DatabaseRewinder.clean_all }
+
+  config.after(:each) { DatabaseRewinder.clean }
+end

--- a/spec/support/poltergeist.rb
+++ b/spec/support/poltergeist.rb
@@ -1,0 +1,4 @@
+require 'capybara/poltergeist'
+
+Capybara.javascript_driver = :poltergeist
+Capybara.default_max_wait_time = 10 if ENV['TRAVIS']


### PR DESCRIPTION
Resolves a bug whereby previews were being skipped for postal summaries
when regenerating via TAP.