### PR TITLE
Alter the information on the 'done' page

### DIFF
--- a/app/views/appointment_summaries/done.html.erb
+++ b/app/views/appointment_summaries/done.html.erb
@@ -1,6 +1,8 @@
 <div class="page-header">
-  <h1><%= title 'Appointment Summary Saved' %></h1>
+  <h1><%= title 'Appointment summary created' %></h1>
 </div>
 
-<p>Appointment details have been saved. A Pension Wise Summary Document will be printed and dispatched to the
-  customer shortly.</p>
+<p>An appointment summary has been created. Digital versions will be sent automatically.</p>
+
+<p>If the customer requested a postal version, download and print the summary to send to them.</p>
+


### PR DESCRIPTION
This improves the information given to the guider
once they have created a summary document.

<img width="658" alt="screen shot 2017-03-16 at 16 57 30" src="https://cloud.githubusercontent.com/assets/6049076/24008475/ab62abc6-0a69-11e7-8a5f-f4a9add5c420.png">
