### PR TITLE
Add supplementary information to the confirmation screen

### DIFF
--- a/app/models/appointment_summary.rb
+++ b/app/models/appointment_summary.rb
@@ -1,4 +1,4 @@
-class AppointmentSummary < ApplicationRecord
+class AppointmentSummary < ApplicationRecord # rubocop:disable ClassLength
   deprecated_columns :income_in_retirement, :guider_organisation
 
   enum notify_status: %i(pending delivered failed ignoring)
@@ -115,6 +115,14 @@ class AppointmentSummary < ApplicationRecord
       county,
       postcode
     ].reject(&:empty?).join("\n")
+  end
+
+  def supplementary_info_selected?
+    supplementary_benefits ||
+      supplementary_debt ||
+      supplementary_ill_health ||
+      supplementary_defined_benefit_pensions ||
+      supplementary_pension_transfers
   end
 
   private

--- a/app/models/appointment_summary.rb
+++ b/app/models/appointment_summary.rb
@@ -103,7 +103,7 @@ class AppointmentSummary < ApplicationRecord
   end
 
   def full_name
-    "#{first_name} #{last_name}"
+    "#{title} #{first_name} #{last_name}"
   end
 
   def postal_address

--- a/app/views/appointment_summaries/confirm.html.erb
+++ b/app/views/appointment_summaries/confirm.html.erb
@@ -36,6 +36,22 @@
           <td class="active" width="35%"><b>Guider Name</b></td>
           <td><%= @appointment_summary.guider_name %></td>
         </tr>
+        <tr>
+          <td class="active" width="35%"><b>Supplementary info</b></td>
+          <td>
+            <% if @appointment_summary.supplementary_info_selected? %>
+              <ul>
+                <%= content_tag(:li, 'Benefits') if @appointment_summary.supplementary_benefits %>
+                <%= content_tag(:li, 'Debt') if @appointment_summary.supplementary_debt %>
+                <%= content_tag(:li, 'Ill Health') if @appointment_summary.supplementary_ill_health %>
+                <%= content_tag(:li, 'Defined Benefit Pensions') if @appointment_summary.supplementary_defined_benefit_pensions %>
+                <%= content_tag(:li, 'Pension Transfers') if @appointment_summary.supplementary_pension_transfers %>
+              </ul>
+            <% else %>
+              None selected
+            <% end %>
+          </td>
+        </tr>
       </tbody>
     </table>
     <div class="confirm-submit-buttons">


### PR DESCRIPTION
This will display what supplementary info was selected
on the previous screen when creating the summary document.

This helps the guiders understand what will be displayed
in the summary document when sent out/printed

<img width="772" alt="screen shot 2017-03-20 at 12 10 40" src="https://cloud.githubusercontent.com/assets/6049076/24099283/421c5be4-0d66-11e7-963b-70a078263d36.png">

