### PR TITLE
Add functionality for face to face summaries

### DIFF
--- a/app/controllers/appointment_summaries_controller.rb
+++ b/app/controllers/appointment_summaries_controller.rb
@@ -91,6 +91,7 @@ class AppointmentSummariesController < ApplicationController
   def telephone_appointment?
     current_user.has_permission?(User::TELEPHONE_APPOINTMENT_PERMISSION)
   end
+  helper_method :telephone_appointment?
 
   def appointment_summary_params
     params

--- a/app/controllers/appointment_summaries_controller.rb
+++ b/app/controllers/appointment_summaries_controller.rb
@@ -80,7 +80,7 @@ class AppointmentSummariesController < ApplicationController
   end
 
   def send_notifications(appointment_summary)
-    CreateTapActivity.perform_later(appointment_summary, current_user)
+    CreateTapActivity.perform_later(appointment_summary, current_user) if telephone_appointment?
     NotifyViaEmail.perform_later(appointment_summary) if appointment_summary.can_be_emailed?
   end
 

--- a/app/controllers/appointment_summaries_controller.rb
+++ b/app/controllers/appointment_summaries_controller.rb
@@ -97,7 +97,7 @@ class AppointmentSummariesController < ApplicationController
     params
       .require(:appointment_summary)
       .permit(AppointmentSummary.editable_column_names)
-      .merge(user: current_user)
+      .merge(user: current_user, telephone_appointment: telephone_appointment?)
   end
 
   def ajax_response_paths(appointment_summary)

--- a/app/models/appointment_summary.rb
+++ b/app/models/appointment_summary.rb
@@ -74,6 +74,7 @@ class AppointmentSummary < ApplicationRecord # rubocop:disable ClassLength
   validates :appointment_type, inclusion: { in: %w(standard 50_54) }
   validates :number_of_previous_appointments, inclusion: { in: 0..3 }
   validates :email, format: EMAIL_REGEXP
+  validates :telephone_appointment, inclusion: { in: [true, false] }
 
   def self.editable_column_names
     column_names - %w(id created_at updated_at user_id notification_id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,9 @@ class User < ApplicationRecord
   include GDS::SSO::User
   serialize :permissions, Array
 
+  TELEPHONE_APPOINTMENT_PERMISSION = 'phone_bookings'.freeze
+  FACE_TO_FACE_PERMISSION = 'signin'.freeze
+
   deprecated_columns :admin, :first_name, :last_name, :encrypted_password, :sign_in_count, :current_sign_in_at,
                      :last_sign_in_at, :current_sign_in_ip, :last_sign_in_ip, :confirmation_token, :confirmed_at,
                      :confirmation_sent_at, :unconfirmed_email, :failed_attempts, :unlock_token, :locked_at,

--- a/app/services/appointment_summary_csv.rb
+++ b/app/services/appointment_summary_csv.rb
@@ -3,6 +3,7 @@ class AppointmentSummaryCsv < CsvGenerator
   def attributes # rubocop:disable Metrics/MethodLength
     %w(
       id
+      telephone_appointment
       date_of_appointment
       value_of_pension_pots_is_approximate
       count_of_pension_pots

--- a/app/services/notify_delivery.rb
+++ b/app/services/notify_delivery.rb
@@ -10,7 +10,7 @@ class NotifyDelivery
     response = client.get_notification(appointment_summary.notification_id)
 
     process_response(response, appointment_summary)
-    notify_tap(appointment_summary)
+    notify_tap(appointment_summary) if appointment_summary.telephone_appointment?
   rescue Notifications::Client::RequestError
     appointment_summary.stop_checking!
   end

--- a/app/views/admin/appointment_summaries/index.html.erb
+++ b/app/views/admin/appointment_summaries/index.html.erb
@@ -43,7 +43,7 @@
     <% @appointment_form.paginated_results.each do |summary| %>
       <tr class="t-appointment">
         <td><%= summary.reference_number %></td>
-        <td><%= summary.guider_name %></td>
+        <td><%= summary.guider_name %> (<%= summary.telephone_appointment? ? 'phone' : 'F2F' %>)</td>
         <td><%= "#{summary.title} #{summary.first_name} #{summary.last_name}" %></td>
         <td><%= summary.date_of_appointment.to_s(:gov_uk) %></td>
         <td><%= summary.requested_digital ? 'Yes' : 'No' %></td>

--- a/app/views/appointment_summaries/index.html.erb
+++ b/app/views/appointment_summaries/index.html.erb
@@ -46,7 +46,7 @@
     <% @appointment_form.results.each do |summary| %>
       <tr class="t-appointment">
         <td class="t-reference-number"><%= summary.reference_number %></td>
-        <td><%= summary.guider_name %></td>
+        <td><%= summary.guider_name %> (<%= summary.telephone_appointment? ? 'phone' : 'F2F' %>)</td>
         <td><%= "#{summary.title} #{summary.first_name} #{summary.last_name}" %></td>
         <td><%= summary.date_of_appointment.to_s(:gov_uk) %></td>
         <td><%= summary.created_at.to_s(:govuk_date) %></td>

--- a/app/views/appointment_summaries/new.html.erb
+++ b/app/views/appointment_summaries/new.html.erb
@@ -481,14 +481,14 @@
 
           <div class="radio">
             <label>
-              <%= f.radio_button :requested_digital, 'true',
+              <%= f.radio_button :requested_digital, true,
                                  class: 't-requested-digital' %>
               Email
             </label>
           </div>
           <div class="radio">
             <label>
-              <%= f.radio_button :requested_digital, 'false',
+              <%= f.radio_button :requested_digital, false,
                                  class: 't-requested-postal' %>
               Post
             </label>

--- a/app/views/appointment_summaries/new.html.erb
+++ b/app/views/appointment_summaries/new.html.erb
@@ -19,17 +19,17 @@
 
       <div class="form-group">
         <%= f.label :first_name %>
-        <%= f.text_field :first_name, class: %w(form-control input-md-3 t-first-name), readonly: true %>
+        <%= f.text_field :first_name, class: %w(form-control input-md-3 t-first-name), readonly: telephone_appointment? %>
       </div>
 
       <div class="form-group">
         <%= f.label :last_name %>
-        <%= f.text_field :last_name, class: %w(form-control input-md-3 t-last-name), readonly: true %>
+        <%= f.text_field :last_name, class: %w(form-control input-md-3 t-last-name), readonly: telephone_appointment? %>
       </div>
 
       <div class="form-group">
         <%= f.label :email %>
-        <%= f.text_field :email, class: %w(form-control t-email input-md-3), readonly: true %>
+        <%= f.text_field :email, class: %w(form-control t-email input-md-3), readonly: telephone_appointment? %>
       </div>
 
       <h3 id="postal-address-heading">Address</h3>
@@ -74,12 +74,12 @@
       <div class="form-group">
         <%= f.label :date_of_appointment %>
         <%= f.date_field :date_of_appointment,
-                         class: %w(form-control input-md-2 t-date-of-appointment), readonly: true %>
+                         class: %w(form-control input-md-2 t-date-of-appointment), readonly: telephone_appointment? %>
       </div>
 
       <div class="form-group">
         <%= f.label :reference_number %>
-        <%= f.text_field :reference_number, class: %w(form-control input-md-2 t-reference-number), readonly: true %>
+        <%= f.text_field :reference_number, class: %w(form-control input-md-2 t-reference-number), readonly: telephone_appointment? %>
       </div>
 
       <div class="form-group">
@@ -89,13 +89,13 @@
           </legend>
           <div class="radio">
             <%= f.label :appointment_type, value: 'standard' do %>
-              <%= f.radio_button :appointment_type, 'standard', class: 't-appointment-type-standard', disabled: true %>
+              <%= f.radio_button :appointment_type, 'standard', class: 't-appointment-type-standard', disabled: telephone_appointment? %>
               For customers aged 55 or over
             <% end %>
           </div>
           <div class="radio">
             <%= f.label :appointment_type, value: '50_54' do %>
-              <%= f.radio_button :appointment_type, '50_54', class: 't-appointment-type-50-54', disabled: true %>
+              <%= f.radio_button :appointment_type, '50_54', class: 't-appointment-type-50-54', disabled: telephone_appointment? %>
               For customers aged 50 to 54
             <% end %>
           </div>
@@ -167,7 +167,7 @@
 
       <div class="form-group">
         <%= f.label :guider_name %>
-        <%= f.text_field :guider_name, class: %w(form-control input-md-3 t-guider-name), readonly: true %>
+        <%= f.text_field :guider_name, class: %w(form-control input-md-3 t-guider-name), readonly: telephone_appointment? %>
       </div>
 
       <hr>

--- a/app/views/appointment_summaries/summarise_via_tap.html.erb
+++ b/app/views/appointment_summaries/summarise_via_tap.html.erb
@@ -2,5 +2,5 @@
   <h1>Create appointment summary in planner</h1>
 </div>
 
-<p class="help-block">After the appointment status is updated use the Telephone
+<p class="help-block t-use-tap">After the appointment status is updated use the Telephone
 Appointment Planner to create the summary.</p>

--- a/db/migrate/20170530133132_add_telephone_appointment_flag_to_appointment_summaries.rb
+++ b/db/migrate/20170530133132_add_telephone_appointment_flag_to_appointment_summaries.rb
@@ -1,0 +1,5 @@
+class AddTelephoneAppointmentFlagToAppointmentSummaries < ActiveRecord::Migration[5.0]
+  def change
+    add_column :appointment_summaries, :telephone_appointment, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170222151348) do
+ActiveRecord::Schema.define(version: 20170530133132) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,6 +69,7 @@ ActiveRecord::Schema.define(version: 20170222151348) do
     t.boolean  "supplementary_pension_transfers",                  default: false
     t.datetime "notify_completed_at"
     t.integer  "notify_status",                                    default: 0,                null: false
+    t.boolean  "telephone_appointment",                            default: true
     t.index ["user_id"], name: "index_appointment_summaries_on_user_id", using: :btree
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,0 +1,7 @@
+User.find_or_create_by!(name: 'Joe Bloggs', email: 'joe.bloggs@pensionwise.gov.uk') do |user|
+  user.permissions = [
+    'signin',
+    'team_leader',
+    'analyst'
+  ]
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -4,7 +4,19 @@ FactoryGirl.define do
   factory :user do
     sequence(:email) { |n| "user#{n}@example.com" }
     name 'Rick Sanchez'
-    permissions %w(signin team_leader)
+    permissions %w(signin)
+
+    trait :analyst do
+      permissions %w(signin analyst)
+    end
+
+    trait :team_leader do
+      permissions %w(signin team_leader)
+    end
+
+    trait :phone_guider do
+      permissions %w(signin phone_bookings)
+    end
   end
 
   factory :appointment_summary do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -73,5 +73,9 @@ FactoryGirl.define do
       retirement_income_other_income false
       retirement_income_unspecified false
     end
+
+    trait :requested_digital do
+      requested_digital true
+    end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -41,6 +41,7 @@ FactoryGirl.define do
     number_of_previous_appointments 0
     requested_digital false
     email 'joe@bloggs.com'
+    telephone_appointment true
 
     factory :notify_delivered_appointment_summary do
       requested_digital true

--- a/spec/features/accessibility_spec.rb
+++ b/spec/features/accessibility_spec.rb
@@ -2,33 +2,40 @@ require 'rails_helper'
 
 RSpec.feature 'Accessibility' do
   scenario 'Serving a file in standard format' do
-    given_the_customer_prefers_to_receive_documentation_in_standard_format
+    given_i_am_logged_in_as_a_phone_guider
+    and_the_customer_prefers_to_receive_documentation_in_standard_format
     when_we_send_them_their_record_of_guidance
     then_it_should_be_in_standard_format
   end
 
   scenario 'Serving a file in large text format' do
-    given_the_customer_prefers_to_receive_documentation_in_large_text_format
+    given_i_am_logged_in_as_a_phone_guider
+    and_the_customer_prefers_to_receive_documentation_in_large_text_format
     when_we_send_them_their_record_of_guidance
     then_it_should_be_in_large_text_format
   end
 
   scenario 'Serving a file in braille format' do
-    given_the_customer_prefers_to_receive_documentation_in_braille_format
+    given_i_am_logged_in_as_a_phone_guider
+    and_the_customer_prefers_to_receive_documentation_in_braille_format
     when_we_send_them_their_record_of_guidance
     then_it_should_be_in_braille_format
   end
 end
 
-def given_the_customer_prefers_to_receive_documentation_in_standard_format
+def given_i_am_logged_in_as_a_phone_guider
+  create(:user, :phone_guider)
+end
+
+def and_the_customer_prefers_to_receive_documentation_in_standard_format
   @appointment_summary = create(:populated_appointment_summary, format_preference: :standard)
 end
 
-def given_the_customer_prefers_to_receive_documentation_in_large_text_format
+def and_the_customer_prefers_to_receive_documentation_in_large_text_format
   @appointment_summary = create(:populated_appointment_summary, format_preference: :large_text)
 end
 
-def given_the_customer_prefers_to_receive_documentation_in_braille_format
+def and_the_customer_prefers_to_receive_documentation_in_braille_format
   @appointment_summary = create(:populated_appointment_summary, format_preference: :braille)
 end
 

--- a/spec/features/appointment_summary_browser_spec.rb
+++ b/spec/features/appointment_summary_browser_spec.rb
@@ -19,18 +19,18 @@ RSpec.feature 'Browsing appointment summaries' do
   end
 
   scenario 'Attempting to view the Appointment Summaries' do
-    given_i_am_logged_but_not_a_pension_wise_administrator
+    given_i_am_logged_in_but_not_a_pension_wise_administrator
     when_i_visit_the_summary_browser
     then_i_am_denied_access
   end
 end
 
 def given_i_am_logged_in_as_a_pension_wise_administrator
-  create(:user, permissions: ['analyst'])
+  create(:user, :analyst)
 end
 
-def given_i_am_logged_but_not_a_pension_wise_administrator
-  create(:user, permissions: ['signon'])
+def given_i_am_logged_in_but_not_a_pension_wise_administrator
+  create(:user)
 end
 
 def and_there_are_existing_appointment_summaries

--- a/spec/features/back_from_confirmation_spec.rb
+++ b/spec/features/back_from_confirmation_spec.rb
@@ -2,14 +2,19 @@ require 'rails_helper'
 
 RSpec.feature 'Revising summary details' do
   scenario 'Going back after confirmation' do
-    given_appointment_details_are_captured
+    given_i_am_logged_in_as_a_phone_guider
+    and_appointment_details_are_captured
     and_i_am_on_the_confirmation_page
     when_i_go_back_to_the_appointment_details
     then_the_previously_captured_details_are_prepopulated
   end
 end
 
-def given_appointment_details_are_captured
+def given_i_am_logged_in_as_a_phone_guider
+  create(:user, :phone_guider)
+end
+
+def and_appointment_details_are_captured
   @appointment_summary = build(:populated_appointment_summary)
 
   page = AppointmentSummaryPage.new

--- a/spec/features/delivery_methods_spec.rb
+++ b/spec/features/delivery_methods_spec.rb
@@ -2,23 +2,29 @@ require 'rails_helper'
 
 RSpec.feature 'Summary Document delivery methods' do
   scenario 'Digital delivery' do
-    given_the_customer_requested_a_digital_appointment_summary
+    given_i_am_logged_in_as_a_phone_guider
+    and_the_customer_requested_a_digital_appointment_summary
     when_i_create_their_summary_document
     then_we_should_know_that_the_customer_requested_a_digital_version
   end
 
   scenario 'Postal delivery' do
-    given_the_customer_requested_a_postal_appointment_summary
+    given_i_am_logged_in_as_a_phone_guider
+    and_the_customer_requested_a_postal_appointment_summary
     when_i_create_their_summary_document
     then_we_should_know_that_the_customer_requested_a_postal_version
   end
 end
 
-def given_the_customer_requested_a_digital_appointment_summary
+def given_i_am_logged_in_as_a_phone_guider
+  create(:user, :phone_guider)
+end
+
+def and_the_customer_requested_a_digital_appointment_summary
   @appointment_summary = create(:populated_appointment_summary, requested_digital: true)
 end
 
-def given_the_customer_requested_a_postal_appointment_summary
+def and_the_customer_requested_a_postal_appointment_summary
   @appointment_summary = create(:populated_appointment_summary, requested_digital: false)
 end
 

--- a/spec/features/email_notification_spec.rb
+++ b/spec/features/email_notification_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.feature 'Email notification' do
   scenario 'Email notification of summary document location' do
-    given_the_customer_requested_a_digital_appointment_summary
+    given_i_am_logged_in_as_a_phone_guider
+    and_the_customer_requested_a_digital_appointment_summary
     when_i_create_their_summary_document
     then_the_customer_should_be_notified_by_email
   end
@@ -15,12 +16,16 @@ RSpec.feature 'Email notification' do
   end
 end
 
-def given_the_customer_requested_a_digital_appointment_summary
-  @appointment_summary = create(:populated_appointment_summary, requested_digital: true)
+def given_i_am_logged_in_as_a_phone_guider
+  create(:user, :phone_guider)
 end
 
 def given_i_am_logged_in_as_a_pension_wise_administrator
-  create(:user, permissions: ['analyst'])
+  create(:user, :analyst)
+end
+
+def and_the_customer_requested_a_digital_appointment_summary
+  @appointment_summary = create(:populated_appointment_summary, requested_digital: true)
 end
 
 def and_the_customer_failed_to_receive_an_email_notification_due_to_an_incorrect_email_address

--- a/spec/features/email_notification_spec.rb
+++ b/spec/features/email_notification_spec.rb
@@ -60,12 +60,5 @@ def when_i_update_their_email_address
 end
 
 def then_the_customer_should_be_notified_by_email
-  last_job = ActiveJob::Base.queue_adapter.enqueued_jobs.last
-  expect(last_job).to eq(
-    job: NotifyViaEmail,
-    args: [
-      { '_aj_globalid' => "gid://output/AppointmentSummary/#{AppointmentSummary.last.id}" }
-    ],
-    queue: 'default'
-  )
+  assert_enqueued_jobs 1, only: NotifyViaEmail
 end

--- a/spec/features/face_to_face_summary_creation_spec.rb
+++ b/spec/features/face_to_face_summary_creation_spec.rb
@@ -4,7 +4,8 @@ RSpec.feature 'Face to face guider summary creation' do
   scenario 'creating a summary' do
     given_i_am_logged_in_as_a_face_to_face_guider
     when_i_load_the_blank_summary_form
-    then_i_am_able_to_see_the_form
+    and_i_fill_in_the_summary_details
+    then_i_am_able_to_submit_and_confirm_successfully
   end
 end
 
@@ -17,6 +18,17 @@ def when_i_load_the_blank_summary_form
   @appointment_summary_page.load
 end
 
-def then_i_am_able_to_see_the_form
-  expect(@appointment_summary_page).to have_submit
+def and_i_fill_in_the_summary_details
+  template = build(:populated_appointment_summary)
+  @appointment_summary_page.fill_in(template, face_to_face: true)
+end
+
+def then_i_am_able_to_submit_and_confirm_successfully
+  @appointment_summary_page.submit.click
+
+  @confirmation_page = ConfirmationPage.new
+  @confirmation_page.confirm.click
+
+  @done_page = DonePage.new
+  expect(@done_page).to be_displayed
 end

--- a/spec/features/face_to_face_summary_creation_spec.rb
+++ b/spec/features/face_to_face_summary_creation_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.feature 'Face to face guider summary creation' do
+  scenario 'creating a summary' do
+    given_i_am_logged_in_as_a_face_to_face_guider
+    when_i_load_the_blank_summary_form
+    then_i_am_able_to_see_the_form
+  end
+end
+
+def given_i_am_logged_in_as_a_face_to_face_guider
+  create(:user)
+end
+
+def when_i_load_the_blank_summary_form
+  @appointment_summary_page = AppointmentSummaryPage.new
+  @appointment_summary_page.load
+end
+
+def then_i_am_able_to_see_the_form
+  expect(@appointment_summary_page).to have_submit
+end

--- a/spec/features/face_to_face_summary_creation_spec.rb
+++ b/spec/features/face_to_face_summary_creation_spec.rb
@@ -38,18 +38,9 @@ def then_i_am_able_to_submit_and_confirm_successfully
 end
 
 def and_the_customer_should_be_notified_by_email
-  job = ActiveJob::Base.queue_adapter.enqueued_jobs.last
-  expect(job).to eq(
-    job: NotifyViaEmail,
-    args: [
-      { '_aj_globalid' => "gid://output/AppointmentSummary/#{AppointmentSummary.last.id}" }
-    ],
-    queue: 'default'
-  )
+  assert_enqueued_jobs 1, only: NotifyViaEmail
 end
 
 def and_no_activity_should_be_created_on_tap
-  ActiveJob::Base.queue_adapter.enqueued_jobs.each do |job|
-    expect(job[:job]).not_to eq CreateTapActivity
-  end
+  assert_enqueued_jobs 0, only: CreateTapActivity
 end

--- a/spec/features/ineligibility_letter_spec.rb
+++ b/spec/features/ineligibility_letter_spec.rb
@@ -2,13 +2,18 @@ require 'rails_helper'
 
 RSpec.feature 'Ineligibility letter' do
   scenario 'Customers without a defined contribution pension pot receive an ineligibility letter' do
-    given_the_customer_does_not_have_a_defined_contribution_pension_pot
+    given_i_am_logged_in_as_a_phone_guider
+    and_the_customer_does_not_have_a_defined_contribution_pension_pot
     when_they_have_had_a_pension_wise_appointment
     then_we_should_send_them_an_ineligibility_letter
   end
 end
 
-def given_the_customer_does_not_have_a_defined_contribution_pension_pot
+def given_i_am_logged_in_as_a_phone_guider
+  create(:user, :phone_guider)
+end
+
+def and_the_customer_does_not_have_a_defined_contribution_pension_pot
   @appointment_summary = create(:populated_appointment_summary, has_defined_contribution_pension: 'no')
 end
 

--- a/spec/features/phone_summary_creation_spec.rb
+++ b/spec/features/phone_summary_creation_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.feature 'Phone guider summary creation' do
+  scenario 'attempting to create a summary from scratch' do
+    given_i_am_logged_in_as_a_phone_guider
+    when_i_attempt_to_load_the_blank_summary_form
+    then_i_am_told_to_use_tap
+  end
+
+  scenario 'creating a summary with existing data' do
+    given_i_am_logged_in_as_a_phone_guider
+    when_i_load_the_summary_form_with_preset_data
+    and_i_fill_in_the_remaining_details
+    then_i_am_able_to_submit_and_confirm_successfully
+  end
+end
+
+def given_i_am_logged_in_as_a_phone_guider
+  create(:user, :phone_guider)
+end
+
+def when_i_attempt_to_load_the_blank_summary_form
+  @appointment_summary_page = AppointmentSummaryPage.new
+  @appointment_summary_page.load
+end
+
+def when_i_load_the_summary_form_with_preset_data
+  @appointment_summary_template = build(:populated_appointment_summary)
+
+  @appointment_summary_page = AppointmentSummaryPage.new
+  @appointment_summary_page.load(@appointment_summary_template)
+end
+
+def and_i_fill_in_the_remaining_details
+  @appointment_summary_page.fill_in(@appointment_summary_template)
+end
+
+def then_i_am_told_to_use_tap
+  expect(@appointment_summary_page).to have_use_tap_warning
+end
+
+def then_i_am_able_to_submit_and_confirm_successfully
+  @appointment_summary_page.submit.click
+
+  @confirmation_page = ConfirmationPage.new
+  @confirmation_page.confirm.click
+
+  @done_page = DonePage.new
+  expect(@done_page).to be_displayed
+end

--- a/spec/features/phone_summary_creation_spec.rb
+++ b/spec/features/phone_summary_creation_spec.rb
@@ -54,24 +54,9 @@ def then_i_am_able_to_submit_and_confirm_successfully
 end
 
 def and_the_activity_should_be_created_on_tap
-  job = ActiveJob::Base.queue_adapter.enqueued_jobs[-2]
-  expect(job).to eq(
-    job: CreateTapActivity,
-    args: [
-      { '_aj_globalid' => "gid://output/AppointmentSummary/#{AppointmentSummary.last.id}" },
-      { '_aj_globalid' => "gid://output/User/#{User.first.id}" }
-    ],
-    queue: 'default'
-  )
+  assert_enqueued_jobs 1, only: CreateTapActivity
 end
 
 def and_the_customer_should_be_notified_by_email
-  job = ActiveJob::Base.queue_adapter.enqueued_jobs.last
-  expect(job).to eq(
-    job: NotifyViaEmail,
-    args: [
-      { '_aj_globalid' => "gid://output/AppointmentSummary/#{AppointmentSummary.last.id}" }
-    ],
-    queue: 'default'
-  )
+  assert_enqueued_jobs 1, only: NotifyViaEmail
 end

--- a/spec/features/record_of_guidance_contents_spec.rb
+++ b/spec/features/record_of_guidance_contents_spec.rb
@@ -2,49 +2,59 @@ require 'rails_helper'
 
 RSpec.feature 'Record of guidance contents' do
   scenario 'Records of guidance include the information provided to us by the customer' do
-    given_we_have_captured_the_customers_details_in_an_appointment_summary
+    given_i_am_logged_in_as_a_phone_guider
+    and_i_have_captured_the_customers_details_in_an_appointment_summary
     when_we_send_them_their_record_of_guidance
     then_the_record_of_guidance_should_include_their_details
   end
 
   context 'supplementary information is included' do
     scenario 'about benefits and pension income' do
-      given_the_customer_requires_supplementary_information_about('benefits and pension income')
+      given_i_am_logged_in_as_a_phone_guider
+      and_the_customer_requires_supplementary_information_about('benefits and pension income')
       when_we_send_them_their_record_of_guidance
       then_it_should_include_supplementary_information_about('benefits and pension income')
     end
 
     scenario 'about debt and pensions' do
-      given_the_customer_requires_supplementary_information_about('debt and pensions')
+      given_i_am_logged_in_as_a_phone_guider
+      and_the_customer_requires_supplementary_information_about('debt and pensions')
       when_we_send_them_their_record_of_guidance
       then_it_should_include_supplementary_information_about('debt and pensions')
     end
 
     scenario 'about final salary or career average pensions' do
-      given_the_customer_requires_supplementary_information_about('final salary or career average pensions')
+      given_i_am_logged_in_as_a_phone_guider
+      and_the_customer_requires_supplementary_information_about('final salary or career average pensions')
       when_we_send_them_their_record_of_guidance
       then_it_should_include_supplementary_information_about('final salary or career average pensions')
     end
 
     scenario 'about pensions and ill health' do
-      given_the_customer_requires_supplementary_information_about('pensions and ill health')
+      given_i_am_logged_in_as_a_phone_guider
+      and_the_customer_requires_supplementary_information_about('pensions and ill health')
       when_we_send_them_their_record_of_guidance
       then_it_should_include_supplementary_information_about('pensions and ill health')
     end
 
     scenario 'about transfer of pension pot' do
-      given_the_customer_requires_supplementary_information_about('transfer of pension pot')
+      given_i_am_logged_in_as_a_phone_guider
+      and_the_customer_requires_supplementary_information_about('transfer of pension pot')
       when_we_send_them_their_record_of_guidance
       then_it_should_include_supplementary_information_about('transfer of pension pot')
     end
   end
 end
 
-def given_we_have_captured_the_customers_details_in_an_appointment_summary
+def given_i_am_logged_in_as_a_phone_guider
+  create(:user, :phone_guider)
+end
+
+def and_i_have_captured_the_customers_details_in_an_appointment_summary
   @appointment_summary = create(:populated_appointment_summary)
 end
 
-def given_the_customer_requires_supplementary_information_about(topic) # rubocop:disable Metrics/MethodLength
+def and_the_customer_requires_supplementary_information_about(topic) # rubocop:disable Metrics/MethodLength
   @appointment_summary = build(:populated_appointment_summary) do |summary|
     summary.supplementary_benefits = false
     summary.supplementary_debt = false

--- a/spec/features/record_of_guidance_spec.rb
+++ b/spec/features/record_of_guidance_spec.rb
@@ -2,61 +2,73 @@ require 'rails_helper'
 
 RSpec.feature 'Record of guidance' do
   scenario "A customer's details are recorded" do
-    given_i_have_captured_the_customers_details_in_an_appointment_summary
+    given_i_am_logged_in_as_a_phone_guider
+    and_i_have_captured_the_customers_details_in_an_appointment_summary
     when_i_create_their_record_of_guidance
     then_the_customers_details_should_be_recorded
   end
 
   context "Recording of customers' individual circumstances" do
     scenario 'when they plan to continue working for a while' do
-      given_the_customer('plans to continue working for a while')
+      given_i_am_logged_in_as_a_phone_guider
+      and_the_customer('plans to continue working for a while')
       when_i_create_their_record_of_guidance
       then_information_it_should_be_recorded_that('plans to continue working for a while')
     end
 
     scenario 'when they are unsure about plans in retirement' do
-      given_the_customer('is unsure about plans in retirement')
+      given_i_am_logged_in_as_a_phone_guider
+      and_the_customer('is unsure about plans in retirement')
       when_i_create_their_record_of_guidance
       then_information_it_should_be_recorded_that('is unsure about plans in retirement')
     end
 
     scenario 'when they plan to leave money to someone' do
-      given_the_customer('plans to leave money to someone')
+      given_i_am_logged_in_as_a_phone_guider
+      and_the_customer('plans to leave money to someone')
       when_i_create_their_record_of_guidance
       then_information_it_should_be_recorded_that('plans to leave money to someone')
     end
 
     scenario 'when they want flexibility when taking money' do
-      given_the_customer('wants flexibility when taking money')
+      given_i_am_logged_in_as_a_phone_guider
+      and_the_customer('wants flexibility when taking money')
       when_i_create_their_record_of_guidance
       then_information_it_should_be_recorded_that('wants flexibility when taking money')
     end
 
     scenario 'when they want a guaranteed income' do
-      given_the_customer('wants a guaranteed income')
+      given_i_am_logged_in_as_a_phone_guider
+      and_the_customer('wants a guaranteed income')
       when_i_create_their_record_of_guidance
       then_information_it_should_be_recorded_that('wants a guaranteed income')
     end
 
     scenario 'when they need a certain amount of money now' do
-      given_the_customer('needs a certain amount of money now')
+      given_i_am_logged_in_as_a_phone_guider
+      and_the_customer('needs a certain amount of money now')
       when_i_create_their_record_of_guidance
       then_information_it_should_be_recorded_that('needs a certain amount of money now')
     end
 
     scenario 'when they have poor health' do
-      given_the_customer('has poor health')
+      given_i_am_logged_in_as_a_phone_guider
+      and_the_customer('has poor health')
       when_i_create_their_record_of_guidance
       then_information_it_should_be_recorded_that('has poor health')
     end
   end
 end
 
-def given_i_have_captured_the_customers_details_in_an_appointment_summary
+def given_i_am_logged_in_as_a_phone_guider
+  create(:user, :phone_guider)
+end
+
+def and_i_have_captured_the_customers_details_in_an_appointment_summary
   @appointment_summary = build(:populated_appointment_summary)
 end
 
-def given_the_customer(circumstances) # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
+def and_the_customer(circumstances) # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
   @appointment_summary = build(:populated_appointment_summary) do |summary|
     summary.continue_working = false
     summary.unsure = false

--- a/spec/features/reprint_summary_spec.rb
+++ b/spec/features/reprint_summary_spec.rb
@@ -18,12 +18,12 @@ RSpec.feature 'Reprint Summary Document' do
 end
 
 def given_i_log_in_to_reprint_a_summary_document
-  @user = create(:user, permissions: ['team_leader'])
+  @user = create(:user, :team_leader)
   @appointment_summary = create(:appointment_summary)
 end
 
 def given_i_log_in_to_see_a_report_of_summary_documents_sent_by_post
-  @user = create(:user, permissions: ['team_leader'])
+  @user = create(:user, :team_leader)
 
   create(:appointment_summary, requested_digital: true)
   create(:appointment_summary, date_of_appointment: Time.zone.yesterday)

--- a/spec/features/tap_summary_document_generation_spec.rb
+++ b/spec/features/tap_summary_document_generation_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.feature 'Appointment Summaries', js: true do
   scenario 'Regenerating an existing appointment summary' do
-    given_an_existing_appointment_summary
+    given_i_am_logged_in_as_a_phone_guider
+    and_an_existing_appointment_summary
     when_the_guider_attempts_to_regenerate_the_summary
     then_the_existing_appointment_summary_is_displayed
     and_the_details_provided_by_tap_are_displayed
@@ -12,7 +13,11 @@ RSpec.feature 'Appointment Summaries', js: true do
     then_the_existing_summary_is_updated
   end
 
-  def given_an_existing_appointment_summary
+  def given_i_am_logged_in_as_a_phone_guider
+    create(:user, :phone_guider)
+  end
+
+  def and_an_existing_appointment_summary
     @summary = create(:appointment_summary, reference_number: '123456')
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,6 +11,7 @@ Dir[File.join(File.dirname(__FILE__), 'support', '**', '*.rb')].each { |f| requi
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
   config.include UserHelpers
+  config.include ActiveJob::TestHelper
 
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
   config.infer_spec_type_from_file_location!

--- a/spec/services/appointment_summary_csv_spec.rb
+++ b/spec/services/appointment_summary_csv_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe AppointmentSummaryCsv do
       expect(subject.first.chomp.split(separator)).to match_array(
         %w(
           id
+          telephone_appointment
           date_of_appointment
           value_of_pension_pots_is_approximate
           count_of_pension_pots
@@ -66,6 +67,7 @@ RSpec.describe AppointmentSummaryCsv do
       expect(subject.last.chomp.split(separator, -1)).to eq(
         [
           appointment.to_param,
+          appointment.telephone_appointment.to_s,
           appointment.date_of_appointment.to_s,
           appointment.value_of_pension_pots_is_approximate.to_s,
           appointment.count_of_pension_pots.to_s,

--- a/spec/support/pages/appointment_summary_page.rb
+++ b/spec/support/pages/appointment_summary_page.rb
@@ -98,7 +98,7 @@ class AppointmentSummaryPage < SitePrism::Page
     end
   end
 
-  def fill_in(appointment_summary)
+  def fill_in(appointment_summary, face_to_face: false)
     fill_in_customer_details(appointment_summary)
     fill_in_pension_pot_details(appointment_summary)
     fill_in_income_in_retirement_details(appointment_summary)
@@ -107,6 +107,7 @@ class AppointmentSummaryPage < SitePrism::Page
     fill_in_format_preference(appointment_summary)
     fill_in_digital_request(appointment_summary)
     fill_in_supplementary_information(appointment_summary)
+    fill_in_face_to_face_only_details(appointment_summary) if face_to_face
   end
 
   private
@@ -181,6 +182,23 @@ class AppointmentSummaryPage < SitePrism::Page
     supplementary_ill_health.set appointment_summary.supplementary_ill_health
     supplementary_defined_benefit_pensions.set appointment_summary.supplementary_defined_benefit_pensions
     supplementary_pension_transfers.set appointment_summary.supplementary_pension_transfers
+  end
+
+  def fill_in_face_to_face_only_details(appointment_summary)
+    first_name.set appointment_summary.first_name
+    last_name.set appointment_summary.last_name
+    email.set appointment_summary.email
+    reference_number.set appointment_summary.reference_number
+    guider_name.set appointment_summary.guider_name
+    date_of_appointment.set appointment_summary.date_of_appointment
+    fill_in_format_preference(appointment_summary)
+  end
+
+  def fill_in_appointment_type(appointment_summary)
+    case appointment_summary.appointment_type
+    when 'standard' then appointment_type_standard.set true
+    when 'appointment_50_54' then appointment_type_appointment_50_54.set true
+    end
   end
 end
 # rubocop:enable ClassLength

--- a/spec/support/pages/appointment_summary_page.rb
+++ b/spec/support/pages/appointment_summary_page.rb
@@ -7,6 +7,8 @@ class AppointmentSummaryPage < SitePrism::Page
   set_url '/appointment_summaries/new{?params*}'
   set_url_matcher %r{/appointment_summaries/new}
 
+  element :use_tap_warning, '.t-use-tap'
+
   element :title, '.t-title'
   element :first_name, '.t-first-name'
   element :last_name, '.t-last-name'
@@ -69,12 +71,12 @@ class AppointmentSummaryPage < SitePrism::Page
 
   element :submit, '.t-submit'
 
-  def load(appointment_summary)
-    super(
-      {
-        params: params(appointment_summary)
-      }
-    )
+  def load(appointment_summary = nil)
+    if appointment_summary
+      super(params: params(appointment_summary))
+    else
+      super()
+    end
   end
 
   def params(appointment_summary)


### PR DESCRIPTION
Changes to allow summaries for face to face bookings, allowing the form to be completed from scratch, without certain fields disabled as we do for tap.