### PR TITLE
Loosen validation on reference number to allow any string

### DIFF
--- a/app/models/appointment_summary.rb
+++ b/app/models/appointment_summary.rb
@@ -45,7 +45,7 @@ class AppointmentSummary < ApplicationRecord # rubocop:disable ClassLength
   validates :date_of_appointment, timeliness: { on_or_before: -> { Time.zone.today },
                                                 on_or_after: Date.new(2015),
                                                 type: :date }
-  validates :reference_number, numericality: { only_integer: true, allow_blank: true }, presence: true
+  validates :reference_number, presence: true
 
   with_options numericality: true, allow_blank: true, if: :eligible_for_guidance? do |eligible|
     eligible.validates :value_of_pension_pots

--- a/spec/models/appointment_summary_spec.rb
+++ b/spec/models/appointment_summary_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe AppointmentSummary, type: :model do
   it { is_expected.to_not allow_value(Time.zone.tomorrow.to_s).for(:date_of_appointment) }
 
   it { is_expected.to validate_presence_of(:reference_number) }
-  it { is_expected.to validate_numericality_of(:reference_number).only_integer }
 
   it { is_expected.to_not validate_presence_of(:value_of_pension_pots) }
   it { is_expected.to validate_numericality_of(:value_of_pension_pots) }


### PR DESCRIPTION
Appointments booked via other systems have alphanumeric reference numbers, so this allows sharing of the same values to be used for summary documents.