### PR TITLE
Add Mailgun email validation to summary form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,64 +1,68 @@
-# frozen_string_literal: true
-source 'https://rubygems.org'
-
 ruby IO.read('.ruby-version').strip
 
 # force Bundler to use HTTPS for github repos
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
-gem 'autoprefixer-rails'
-gem 'bootstrap-kaminari-views'
-gem 'bugsnag'
-gem 'deprecated_columns'
-gem 'faraday'
-gem 'foreman'
-gem 'gaffe'
-gem 'gds-sso'
-gem 'govuk_admin_template'
-gem 'jc-validates_timeliness'
-gem 'kaminari'
-gem 'meta-tags'
-gem 'net-sftp'
-gem 'newrelic_rpm'
-gem 'notifications-ruby-client'
-gem 'output-templates', '~> 4.7.0', github: 'guidance-guarantee-programme/output-templates'
-gem 'pg'
-gem 'plek'
-gem 'princely', github: 'mbleigh/princely'
-gem 'puma'
-gem 'rails', '5.1.1'
-gem 'rails-i18n', '~> 5.0.0'
-gem 'retriable'
-gem 'sassc-rails'
-gem 'sidekiq'
-gem 'sinatra', require: nil # Sidekiq UI
-gem 'telephone_appointments'
-gem 'uglifier', '>= 1.3.0'
-gem 'uk_postcode'
-
-group :development, :test do
-  gem 'database_rewinder'
-  gem 'launchy'
-  gem 'phantomjs-binaries'
-  gem 'poltergeist'
-  gem 'pry-byebug'
-  gem 'rspec-rails'
-  gem 'scss_lint', require: false
+source 'https://rails-assets.org' do
+  gem 'rails-assets-mailgun-validator-jquery', '0.0.3'
 end
 
-group :development do
-  gem 'rubocop', '0.47.1', require: false
-  gem 'web-console', '~> 2.0'
-end
+source 'https://rubygems.org' do # rubocop:disable Metrics/BlockLength
+  gem 'autoprefixer-rails'
+  gem 'bootstrap-kaminari-views'
+  gem 'bugsnag'
+  gem 'deprecated_columns'
+  gem 'faraday'
+  gem 'foreman'
+  gem 'gaffe'
+  gem 'gds-sso'
+  gem 'govuk_admin_template'
+  gem 'jc-validates_timeliness'
+  gem 'kaminari'
+  gem 'meta-tags'
+  gem 'net-sftp'
+  gem 'newrelic_rpm'
+  gem 'notifications-ruby-client'
+  gem 'output-templates', '~> 4.7.0', github: 'guidance-guarantee-programme/output-templates'
+  gem 'pg'
+  gem 'plek'
+  gem 'princely', github: 'mbleigh/princely'
+  gem 'puma'
+  gem 'rails', '5.1.1'
+  gem 'rails-i18n', '~> 5.0.0'
+  gem 'retriable'
+  gem 'sassc-rails'
+  gem 'sidekiq'
+  gem 'sinatra', require: nil # Sidekiq UI
+  gem 'telephone_appointments'
+  gem 'uglifier', '>= 1.3.0'
+  gem 'uk_postcode'
 
-group :test do
-  gem 'database_cleaner'
-  gem 'shoulda-matchers'
-  gem 'site_prism'
-end
+  group :development, :test do
+    gem 'database_rewinder'
+    gem 'launchy'
+    gem 'phantomjs-binaries'
+    gem 'poltergeist'
+    gem 'pry-byebug'
+    gem 'rspec-rails'
+    gem 'scss_lint', require: false
+  end
 
-gem 'factory_girl_rails', group: %i(development test)
+  group :development do
+    gem 'rubocop', '0.47.1', require: false
+    gem 'web-console', '~> 2.0'
+  end
 
-group :staging, :production do
-  gem 'rails_12factor'
+  group :test do
+    gem 'database_cleaner'
+    gem 'shoulda-matchers'
+    gem 'site_prism'
+    gem 'webrick'
+  end
+
+  gem 'factory_girl_rails', group: %i(development test)
+
+  group :staging, :production do
+    gem 'rails_12factor'
+  end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'puma'
 gem 'rails', '5.1.1'
 gem 'rails-i18n', '~> 5.0.0'
 gem 'retriable'
-gem 'sass-rails', '~> 5.0'
+gem 'sassc-rails'
 gem 'sidekiq'
 gem 'sinatra', require: nil # Sidekiq UI
 gem 'telephone_appointments'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,12 +263,17 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
     sass (3.4.24)
-    sass-rails (5.0.6)
-      railties (>= 4.0.0, < 6)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
+    sassc (1.11.2)
+      bundler
+      ffi (~> 1.9.6)
+      sass (>= 3.3.0)
+    sassc-rails (1.3.0)
+      railties (>= 4.0.0)
+      sass
+      sassc (~> 1.9)
+      sprockets (> 2.11)
+      sprockets-rails
+      tilt
     scss_lint (0.53.0)
       rake (>= 0.9, < 13)
       sass (~> 3.4.20)
@@ -361,7 +366,7 @@ DEPENDENCIES
   retriable
   rspec-rails
   rubocop (= 0.47.1)
-  sass-rails (~> 5.0)
+  sassc-rails
   scss_lint
   shoulda-matchers
   sidekiq

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,7 @@ GIT
     princely (2.0.3)
 
 GEM
+  remote: https://rails-assets.org/
   remote: https://rubygems.org/
   specs:
     actioncable (5.1.1)
@@ -214,6 +215,7 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 5.1.1)
       sprockets-rails (>= 2.0.0)
+    rails-assets-mailgun-validator-jquery (0.0.3)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -323,6 +325,7 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    webrick (1.3.1)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -333,49 +336,51 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  autoprefixer-rails
-  bootstrap-kaminari-views
-  bugsnag
-  database_cleaner
-  database_rewinder
-  deprecated_columns
-  factory_girl_rails
-  faraday
-  foreman
-  gaffe
-  gds-sso
-  govuk_admin_template
-  jc-validates_timeliness
-  kaminari
-  launchy
-  meta-tags
-  net-sftp
-  newrelic_rpm
-  notifications-ruby-client
+  autoprefixer-rails!
+  bootstrap-kaminari-views!
+  bugsnag!
+  database_cleaner!
+  database_rewinder!
+  deprecated_columns!
+  factory_girl_rails!
+  faraday!
+  foreman!
+  gaffe!
+  gds-sso!
+  govuk_admin_template!
+  jc-validates_timeliness!
+  kaminari!
+  launchy!
+  meta-tags!
+  net-sftp!
+  newrelic_rpm!
+  notifications-ruby-client!
   output-templates (~> 4.7.0)!
-  pg
-  phantomjs-binaries
-  plek
-  poltergeist
+  pg!
+  phantomjs-binaries!
+  plek!
+  poltergeist!
   princely!
-  pry-byebug
-  puma
-  rails (= 5.1.1)
-  rails-i18n (~> 5.0.0)
-  rails_12factor
-  retriable
-  rspec-rails
-  rubocop (= 0.47.1)
-  sassc-rails
-  scss_lint
-  shoulda-matchers
-  sidekiq
-  sinatra
-  site_prism
-  telephone_appointments
-  uglifier (>= 1.3.0)
-  uk_postcode
-  web-console (~> 2.0)
+  pry-byebug!
+  puma!
+  rails (= 5.1.1)!
+  rails-assets-mailgun-validator-jquery (= 0.0.3)!
+  rails-i18n (~> 5.0.0)!
+  rails_12factor!
+  retriable!
+  rspec-rails!
+  rubocop (= 0.47.1)!
+  sassc-rails!
+  scss_lint!
+  shoulda-matchers!
+  sidekiq!
+  sinatra!
+  site_prism!
+  telephone_appointments!
+  uglifier (>= 1.3.0)!
+  uk_postcode!
+  web-console (~> 2.0)!
+  webrick!
 
 RUBY VERSION
    ruby 2.4.1p111

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,7 +1,9 @@
 //= require jquery-tiny-pubsub/dist/ba-tiny-pubsub
+//= require mailgun-validator-jquery
 //= require additional-appointment
 //= require consent
 //= require eligibility
+//= require email-validation
 //= require pension-pot-accuracy
 //= require pension-pot-input
 //= require postcode-lookup

--- a/app/assets/javascripts/email-validation.js
+++ b/app/assets/javascripts/email-validation.js
@@ -1,0 +1,112 @@
+(function() {
+  'use strict';
+
+  window.PWO = window.PWO || {};
+
+  var emailValidation = {
+    init: function() {
+      var element = $('.js-email-validation');
+
+      if (element.length) {
+        this.setup(element);
+      }
+    },
+
+    setup: function(element) {
+      this.$element = element;
+      this.$elementWrapper = $('.email-outer');
+
+      this.$element.mailgun_validator({
+        api_key: this.$element.data('api-key'),
+        api_host: this.$element.data('api-host'),
+        in_progress: this.showLoadingSpinner.bind(this),
+        success: this.onSuccess.bind(this),
+        error: this.onError.bind(this)
+      });
+
+      this.insertSuggestionContainer();
+      this.insertLoadingSpinner();
+    },
+
+    onSuccess: function(data) {
+      this.hideLoadingSpinner();
+
+      if (!data.is_valid || data.did_you_mean) {
+        this.showSuggestion(data.is_valid, data.did_you_mean);
+      } else {
+        this.clearSuggestion();
+      }
+    },
+
+    onError: function(message) {
+      this.hideLoadingSpinner();
+      this.$suggestionContainer.html(message);
+    },
+
+    insertLoadingSpinner: function() {
+      if (this.$loadingSpinner) {
+        return;
+      }
+
+      this.$loadingSpinner = $('<div class="ajax-loader ajax-loader--24px hidden"></div>');
+      this.$loadingSpinner.insertAfter(this.$element);
+    },
+
+    showLoadingSpinner: function() {
+      this.clearSuggestion();
+      this.$loadingSpinner.removeClass('hidden');
+    },
+
+    hideLoadingSpinner: function() {
+      this.$loadingSpinner.addClass('hidden');
+    },
+
+    insertSuggestionContainer: function() {
+      if (this.$suggestionContainer) {
+        return;
+      }
+
+      this.$suggestionContainer = $('<div class="form-hint email-suggestion" aria-live="polite" />');
+      this.$suggestionContainer.insertAfter(this.$elementWrapper);
+    },
+
+    showSuggestion: function(isValid, didYouMean) {
+      var messages = [],
+          message;
+
+      if (!isValid) {
+        messages.push("that doesn't look like a valid address");
+      }
+
+      // Null (falsey) if no suggestion
+      if (didYouMean) {
+        messages.push(
+          'did you mean <button class="button-link t-email-suggestion js-populate-suggested-email">' +
+          didYouMean +
+          '</button>?'
+        );
+      }
+
+      message = messages.join(', ');
+      message = message.charAt(0).toUpperCase() + message.slice(1);
+
+      // Insert the message
+      this.$suggestionContainer.html(message);
+
+      // And now add the click behaviour to populate the suggestion
+      $('.js-populate-suggested-email').click(function(event) {
+        event.preventDefault();
+
+        // Populate the suggestion and then remove the message
+        this.$element.val(event.target.innerHTML);
+        this.clearSuggestion();
+      });
+    },
+
+    clearSuggestion: function() {
+      this.$suggestionContainer.empty();
+    }
+  }
+
+  PWO.emailValidation = emailValidation;
+})(jQuery);

--- a/app/assets/javascripts/init.js
+++ b/app/assets/javascripts/init.js
@@ -4,6 +4,7 @@ $(function () {
   PWO.additionalAppointment.init();
   PWO.consent.init();
   PWO.eligibility.init();
+  PWO.emailValidation.init();
   PWO.pensionPotAccuracy.init();
   PWO.pensionPotInput.init();
   PWO.postcodeLookup.init();

--- a/app/assets/stylesheets/components/_ajax_loader.scss
+++ b/app/assets/stylesheets/components/_ajax_loader.scss
@@ -1,0 +1,70 @@
+$loader-color: #000;
+$number-of-circles: 8;
+$sin-of-forty-five-degrees: .70711;
+$circle-animation-length: .8s;
+
+$ajax-loaders: 24px 48px;
+
+.ajax-loader {
+  position: relative;
+
+  &:after {
+    content: "";
+    display: block;
+    border-radius: 50%;
+    position: absolute;
+    animation-fill-mode: forwards;
+  }
+}
+
+@each $loader-size in $ajax-loaders {
+  $loader-size-half: $loader-size / 2;
+  $circle-size: $loader-size / $number-of-circles;
+  $circle-size-half: $circle-size / 2;
+  $forty-five-degrees-in-pixels: (1 - $sin-of-forty-five-degrees) * $loader-size-half;
+
+  $circles:
+    (x: 0, y: $loader-size-half, spread: $circle-size-half $circle-size-half / 2 0 0 0 0 0 0),
+    (x: -($loader-size-half - $forty-five-degrees-in-pixels), y: $loader-size-half - $forty-five-degrees-in-pixels, spread: 0 $circle-size-half $circle-size-half / 2 0 0 0 0 0),
+    (x: -$loader-size-half, y: 0, spread: 0 0 $circle-size-half $circle-size-half / 2 0 0 0 0),
+    (x: -($loader-size-half - $forty-five-degrees-in-pixels), y: -($loader-size-half - $forty-five-degrees-in-pixels), spread: 0 0 0 $circle-size-half $circle-size-half / 2 0 0 0),
+    (x: 0, y: -$loader-size-half, spread: 0 0 0 0 $circle-size-half $circle-size-half / 2 0 0),
+    (x: $loader-size-half - $forty-five-degrees-in-pixels, y: -($loader-size-half - $forty-five-degrees-in-pixels), spread: 0 0 0 0 0 $circle-size-half $circle-size-half / 2 0),
+    (x: $loader-size-half, y: 0, spread: 0 0 0 0 0 0 $circle-size-half $circle-size-half / 2),
+    (x: $loader-size-half - $forty-five-degrees-in-pixels, y: $loader-size-half - $forty-five-degrees-in-pixels, spread: $circle-size-half / 2 0 0 0 0 0 0 $circle-size-half);
+
+  @function circle($num) {
+    $line: null;
+
+    @each $circle in $circles {
+      $line: append($line, map-get($circle, "x") map-get($circle, "y") 0 nth(map-get($circle, "spread"), $num) $loader-color, "comma");
+    }
+
+    @return $line;
+  }
+
+  .ajax-loader--#{$loader-size} {
+    width: $loader-size;
+    height: $loader-size;
+
+    &:after {
+      width: $circle-size;
+      height: $circle-size;
+      top: $loader-size-half - $circle-size-half;
+      left: $loader-size-half - $circle-size-half;
+      animation: loader-pulse-#{$loader-size} $circle-animation-length infinite;
+      box-shadow: circle(1);
+    }
+  }
+
+  @keyframes loader-pulse-#{$loader-size} {
+    0% { box-shadow: circle(1); }
+
+    @for $i from 1 through ($number-of-circles - 1) {
+      #{(($i - 1) * 100/$number-of-circles) + 100/$number-of-circles}% { box-shadow: circle($i); }
+      #{(($i - 1) * 100/$number-of-circles) + 100/$number-of-circles + .001}% { box-shadow: circle($i + 1); }
+    }
+
+    99.999% { box-shadow: circle($number-of-circles); }
+  }
+}

--- a/app/assets/stylesheets/components/_button_link.scss
+++ b/app/assets/stylesheets/components/_button_link.scss
@@ -1,0 +1,14 @@
+.button-link {
+  background: transparent;
+  border: 0;
+  color: #337ab7;
+  cursor: pointer;
+  display: inline;
+  padding: 0;
+  text-decoration: underline;
+  user-select: text;
+
+  &:hover {
+    color: #23527c;
+  }
+}

--- a/app/assets/stylesheets/components/_email_outer.scss
+++ b/app/assets/stylesheets/components/_email_outer.scss
@@ -1,0 +1,9 @@
+.email-outer {
+  position: relative;
+
+  .ajax-loader {
+    position: absolute;
+    top: 5px;
+    right: 2%;
+  }
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,4 +18,11 @@ module ApplicationHelper
   def error_messages_for(model)
     render partial: 'shared/errors', locals: { model: model }
   end
+
+  def email_validation_data_attributes
+    {
+      api_key: 'pubkey-b37c931b1fcef90bf2d83b7cdfd6df39',
+      api_host: Rails.env.test? ? 'http://localhost:9293' : nil
+    }
+  end
 end

--- a/app/views/appointment_summaries/new.html.erb
+++ b/app/views/appointment_summaries/new.html.erb
@@ -29,7 +29,9 @@
 
       <div class="form-group">
         <%= f.label :email %>
-        <%= f.text_field :email, class: %w(form-control t-email input-md-3), readonly: telephone_appointment? %>
+        <div class="email-outer input-md-3">
+          <%= f.email_field :email, class: %w(form-control js-email-validation t-email), readonly: telephone_appointment?, data: email_validation_data_attributes %>
+        </div>
       </div>
 
       <h3 id="postal-address-heading">Address</h3>

--- a/spec/features/email_address_suggestions_spec.rb
+++ b/spec/features/email_address_suggestions_spec.rb
@@ -1,0 +1,111 @@
+require 'rails_helper'
+require 'timeout'
+
+RSpec.feature 'Mailgun email verification service suggestions', js: true do
+  scenario 'Mailgun says the email address is invalid' do
+    given_i_am_logged_in_as_a_face_to_face_guider
+    and_i_am_on_the_summary_form
+    with_mock_invalid_mailgun_response do
+      when_i_enter_an_invalid_email_address
+      and_change_focus
+      then_i_should_see_be_warned_of_the_invalid_address
+    end
+  end
+
+  scenario 'Mailgun has a suggestion on the email address' do
+    given_i_am_logged_in_as_a_face_to_face_guider
+    and_i_am_on_the_summary_form
+    with_mock_suggested_mailgun_response do
+      when_i_enter_an_email_address_with_a_suggestion
+      and_change_focus
+      then_i_should_see_a_correction_suggestion
+    end
+  end
+
+  def given_i_am_logged_in_as_a_face_to_face_guider
+    create(:user)
+  end
+
+  def and_i_am_on_the_summary_form
+    @page = AppointmentSummaryPage.new
+    @page.load
+  end
+
+  def with_mock_invalid_mailgun_response(&block)
+    response = {
+      is_valid: false,
+      address: 'something@totallyinvalid',
+      parts: {
+        display_name: nil,
+        local_part: 'something',
+        domain: 'totallyinvalid'
+      },
+      did_you_mean: nil
+    }
+
+    with_mock_mailgun_response(response, block)
+  end
+
+  def with_mock_suggested_mailgun_response(&block)
+    response = {
+      is_valid: false,
+      address: 'joe.bloggs@gmall.com',
+      parts: {
+        display_name: nil,
+        local_part: 'joe.bloggs',
+        domain: 'gmall.com'
+      },
+      did_you_mean: 'joe.bloggs@gmail.com'
+    }
+
+    with_mock_mailgun_response(response, block)
+  end
+
+  def when_i_enter_an_email_address_with_a_suggestion
+    @page.email.set 'joe.bloggs@gmall.com'
+  end
+
+  def when_i_enter_an_invalid_email_address
+    @page.email.set 'something@totallyinvalid'
+  end
+
+  def and_change_focus
+    @page.first_name.click
+  end
+
+  def then_i_should_see_be_warned_of_the_invalid_address
+    expect(@page).to have_content("That doesn't look like a valid address")
+  end
+
+  def then_i_should_see_a_correction_suggestion
+    expect(@page.email_suggestion).to have_content('joe.bloggs@gmail.com')
+  end
+
+  before(:all) do
+    @server = WEBrick::HTTPServer.new(
+      Port: 9293,
+      StartCallback: -> { @running = true },
+      Logger: Rails.logger,
+      AccessLog: Rails.logger
+    )
+
+    @thread = Thread.new { @server.start }
+    Timeout.timeout(1) { :wait until @running }
+  end
+
+  after(:all) do
+    @server.shutdown
+    @thread.kill
+  end
+
+  def with_mock_mailgun_response(response, block)
+    @server.mount '/v2/address/validate', Rack::Handler::WEBrick, lambda { |env|
+      req = Rack::Request.new(env)
+      response_body = "#{req.params['callback']}(#{response.to_json})"
+
+      [200, {}, [response_body]]
+    }
+
+    block.call
+  end
+end

--- a/spec/support/pages/appointment_summary_page.rb
+++ b/spec/support/pages/appointment_summary_page.rb
@@ -53,6 +53,7 @@ class AppointmentSummaryPage < SitePrism::Page
                                     false: '.t-requested-postal'
 
   element :email, '.t-email'
+  element :email_suggestion, '.t-email-suggestion'
   element :supplementary_benefits, '.t-supplementary-benefits'
   element :supplementary_debt, '.t-supplementary-debt'
   element :supplementary_ill_health, '.t-supplementary-ill-health'


### PR DESCRIPTION
Much the same as we've seen before in the other apps.

![Validation capture](http://g.recordit.co/LLQjiEVKsf.gif)

Styles recycled from `pension_guidance` with minor tweaking, but lead to replacing `sass-rails` with `sassc-rails` (as used in `pension_guidance`) because of unsupported syntax (definition if mixins within control flow statements).