### PR TITLE
Add organisation id to csv export

### DIFF
--- a/app/models/appointment_summary.rb
+++ b/app/models/appointment_summary.rb
@@ -118,6 +118,10 @@ class AppointmentSummary < ApplicationRecord # rubocop:disable ClassLength
     ].reject(&:empty?).join("\n")
   end
 
+  def organisation_id
+    user.organisation_content_id
+  end
+
   def supplementary_info_selected?
     supplementary_benefits ||
       supplementary_debt ||

--- a/app/services/appointment_summary_csv.rb
+++ b/app/services/appointment_summary_csv.rb
@@ -4,6 +4,7 @@ class AppointmentSummaryCsv < CsvGenerator
     %w(
       id
       telephone_appointment
+      organisation_id
       date_of_appointment
       value_of_pension_pots_is_approximate
       count_of_pension_pots

--- a/app/services/csv_generator.rb
+++ b/app/services/csv_generator.rb
@@ -22,10 +22,7 @@ class CsvGenerator
   private
 
   def row(record)
-    record
-      .attributes
-      .slice(*attributes)
-      .map { |key, value| format(key, value) }
+    attributes.map { |attribute| format(attribute, record.public_send(attribute)) }
   end
 
   def format(key, value)

--- a/spec/services/appointment_summary_csv_spec.rb
+++ b/spec/services/appointment_summary_csv_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe AppointmentSummaryCsv do
-  let(:appointment) { create(:appointment_summary) }
+  let(:user) { create(:user, organisation_content_id: 'content-id') }
+  let(:appointment) { create(:appointment_summary, user: user) }
   let(:separator) { ',' }
 
   subject { described_class.new(appointment).call.lines }
@@ -12,6 +13,7 @@ RSpec.describe AppointmentSummaryCsv do
         %w(
           id
           telephone_appointment
+          organisation_id
           date_of_appointment
           value_of_pension_pots_is_approximate
           count_of_pension_pots
@@ -68,6 +70,7 @@ RSpec.describe AppointmentSummaryCsv do
         [
           appointment.to_param,
           appointment.telephone_appointment.to_s,
+          appointment.user.organisation_content_id,
           appointment.date_of_appointment.to_s,
           appointment.value_of_pension_pots_is_approximate.to_s,
           appointment.count_of_pension_pots.to_s,


### PR DESCRIPTION
Surfacing the `organisation_content_id` of the user who generated the summary under the column `content_id`.