### PR TITLE
bumping output-templates version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ source 'https://rubygems.org' do # rubocop:disable Metrics/BlockLength
   gem 'net-sftp'
   gem 'newrelic_rpm'
   gem 'notifications-ruby-client'
-  gem 'output-templates', '~> 4.7.0', github: 'guidance-guarantee-programme/output-templates'
+  gem 'output-templates', '~> 4.7.1', github: 'guidance-guarantee-programme/output-templates'
   gem 'pg'
   gem 'plek'
   gem 'princely', github: 'mbleigh/princely'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/guidance-guarantee-programme/output-templates.git
-  revision: 3beff20ba153a85e26e637f248fea93543e49e35
+  revision: fd1176195e1d297553b38d4bd0ef5323cfe25482
   specs:
-    output-templates (4.7.0)
+    output-templates (4.7.1)
       actionview
       sass
 
@@ -355,7 +355,7 @@ DEPENDENCIES
   net-sftp!
   newrelic_rpm!
   notifications-ruby-client!
-  output-templates (~> 4.7.0)!
+  output-templates (~> 4.7.1)!
   pg!
   phantomjs-binaries!
   plek!


### PR DESCRIPTION
Updating version of output-templates based on typo fixes to the summary
document