### PR TITLE
Add ability to customise covering letter content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ source 'https://rubygems.org' do # rubocop:disable Metrics/BlockLength
   gem 'net-sftp'
   gem 'newrelic_rpm'
   gem 'notifications-ruby-client'
-  gem 'output-templates', '~> 4.7.1', github: 'guidance-guarantee-programme/output-templates'
+  gem 'output-templates', '~> 4.8.1', github: 'guidance-guarantee-programme/output-templates'
   gem 'pg'
   gem 'plek'
   gem 'princely', github: 'mbleigh/princely'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/guidance-guarantee-programme/output-templates.git
-  revision: fd1176195e1d297553b38d4bd0ef5323cfe25482
+  revision: 26eedb7068e6be8012380e71ea12383545aa4ba8
   specs:
-    output-templates (4.7.1)
+    output-templates (4.8.1)
       actionview
       sass
 
@@ -355,7 +355,7 @@ DEPENDENCIES
   net-sftp!
   newrelic_rpm!
   notifications-ruby-client!
-  output-templates (~> 4.7.1)!
+  output-templates (~> 4.8.1)!
   pg!
   phantomjs-binaries!
   plek!

--- a/app/domain/output_document.rb
+++ b/app/domain/output_document.rb
@@ -14,6 +14,8 @@ class OutputDocument
   delegate :address_line_1, :address_line_2, :address_line_3, :town, :county, :postcode,
            to: :appointment_summary, prefix: :attendee
 
+  delegate :covering_letter_type, to: :appointment_summary
+
   def initialize(appointment_summary)
     @appointment_summary = appointment_summary
   end

--- a/app/models/appointment_summary.rb
+++ b/app/models/appointment_summary.rb
@@ -70,6 +70,7 @@ class AppointmentSummary < ApplicationRecord # rubocop:disable ClassLength
 
   validates :format_preference, inclusion: { in: %w(standard large_text braille) }
   validates :appointment_type, inclusion: { in: %w(standard 50_54) }
+  validates :covering_letter_type, inclusion: { in: %w(section_32 adjustable_income inherited_pot) }
   validates :number_of_previous_appointments, inclusion: { in: 0..3 }
   validates :email, format: EMAIL_REGEXP
   validates :telephone_appointment, inclusion: { in: [true, false] }

--- a/app/services/appointment_summary_csv.rb
+++ b/app/services/appointment_summary_csv.rb
@@ -24,6 +24,7 @@ class AppointmentSummaryCsv < CsvGenerator
       last_name
       format_preference
       appointment_type
+      covering_letter_type
       has_defined_contribution_pension
       supplementary_benefits
       supplementary_debt

--- a/app/views/appointment_summaries/new.html.erb
+++ b/app/views/appointment_summaries/new.html.erb
@@ -104,6 +104,32 @@
         </fieldset>
       </div>
 
+      <div class="form-group">
+        <fieldset>
+          <legend>
+            <span>Customer has one of the following</span>
+          </legend>
+          <div class="radio">
+            <%= f.label :covering_letter_type, value: 'section_32' do %>
+              <%= f.radio_button :covering_letter_type, 'section_32', class: 't-covering-letter-type-section-32' %>
+              Section 32 arrangement
+            <% end %>
+          </div>
+          <div class="radio">
+            <%= f.label :covering_letter_type, value: 'adjustable_income' do %>
+              <%= f.radio_button :covering_letter_type, 'adjustable_income', class: 't-covering-letter-type-adjustable-income' %>
+              Adjustable income pot in payment
+            <% end %>
+          </div>
+          <div class="radio">
+            <%= f.label :covering_letter_type, value: 'inherited_pot' do %>
+              <%= f.radio_button :covering_letter_type, 'inherited_pot', class: 't-covering-letter-type-inherited-pot' %>
+              Inherited pension pot
+            <% end %>
+          </div>
+        </fieldset>
+      </div>
+
       <div class="form-group if-no-js-hide">
         <fieldset>
           <legend>

--- a/db/migrate/20170710142023_add_covering_letter_type_to_appointment_summaries.rb
+++ b/db/migrate/20170710142023_add_covering_letter_type_to_appointment_summaries.rb
@@ -1,0 +1,5 @@
+class AddCoveringLetterTypeToAppointmentSummaries < ActiveRecord::Migration[5.1]
+  def change
+    add_column :appointment_summaries, :covering_letter_type, :string, null: false, default: ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170622104614) do
+ActiveRecord::Schema.define(version: 20170710142023) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,6 +51,7 @@ ActiveRecord::Schema.define(version: 20170622104614) do
     t.datetime "notify_completed_at"
     t.integer "notify_status", default: 0, null: false
     t.boolean "telephone_appointment", default: true
+    t.string "covering_letter_type", default: "", null: false
     t.index ["user_id"], name: "index_appointment_summaries_on_user_id"
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -38,6 +38,7 @@ FactoryGirl.define do
     value_of_pension_pots 15_000
     format_preference 'standard'
     appointment_type 'standard'
+    covering_letter_type 'section_32'
     number_of_previous_appointments 0
     requested_digital false
     email 'joe@bloggs.com'

--- a/spec/services/appointment_summary_csv_spec.rb
+++ b/spec/services/appointment_summary_csv_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe AppointmentSummaryCsv do
           last_name
           format_preference
           appointment_type
+          covering_letter_type
           has_defined_contribution_pension
           supplementary_benefits
           supplementary_debt
@@ -73,6 +74,7 @@ RSpec.describe AppointmentSummaryCsv do
           appointment.last_name,
           appointment.format_preference,
           appointment.appointment_type,
+          appointment.covering_letter_type,
           appointment.has_defined_contribution_pension.to_s,
           appointment.supplementary_benefits.to_s,
           appointment.supplementary_debt.to_s,

--- a/spec/support/pages/appointment_summary_page.rb
+++ b/spec/support/pages/appointment_summary_page.rb
@@ -37,6 +37,9 @@ class AppointmentSummaryPage < SitePrism::Page
 
   radio_buttons :appointment_type, standard: '.t-appointment-type-standard',
                                    appointment_50_54: '.t-appointment-type-50-54'
+  radio_buttons :covering_letter_type, section_32: '.t-covering-letter-type-section-32',
+                                       adjustable_income: '.t-covering-letter-type-adjustable-income',
+                                       inherited_pot: '.t-covering-letter-type-inherited-pot'
   radio_buttons :first_appointment, yes: '.t-first-appointment-yes',
                                     no: '.t-first-appointment-no'
   radio_buttons :number_of_previous_appointments, zero: '.t-number-of-previous-appointments-0',
@@ -86,6 +89,7 @@ class AppointmentSummaryPage < SitePrism::Page
   def fill_in(appointment_summary, face_to_face: false)
     fill_in_customer_details(appointment_summary)
     fill_in_pension_pot_details(appointment_summary)
+    fill_in_covering_letter_type(appointment_summary)
     fill_in_has_defined_contribution_pension(appointment_summary)
     fill_in_format_preference(appointment_summary)
     fill_in_digital_request(appointment_summary)
@@ -159,6 +163,14 @@ class AppointmentSummaryPage < SitePrism::Page
     case appointment_summary.appointment_type
     when 'standard' then appointment_type_standard.set true
     when 'appointment_50_54' then appointment_type_appointment_50_54.set true
+    end
+  end
+
+  def fill_in_covering_letter_type(appointment_summary)
+    case appointment_summary.covering_letter_type
+    when 'section_32' then covering_letter_type_section_32.set true
+    when 'adjustable_income' then covering_letter_type_adjustable_income.set true
+    when 'inherited_pot' then covering_letter_type_inherited_pot.set true
     end
   end
 end


### PR DESCRIPTION
Introduction of new options in the appointment summary form:

<img width="425" alt="screen shot 2017-07-11 at 12 06 34" src="https://user-images.githubusercontent.com/9943/28065716-b9685148-6631-11e7-8d0f-52e0643778f9.png">

Resulting covering letter, "Section 32 arrangement"

<img width="539" alt="screen shot 2017-07-11 at 12 04 21" src="https://user-images.githubusercontent.com/9943/28065726-cc170550-6631-11e7-9db4-53f8c9fd28fb.png">

Resulting covering letter, "Adjustable income pot in payment"

<img width="544" alt="screen shot 2017-07-11 at 12 04 47" src="https://user-images.githubusercontent.com/9943/28065741-dff5926c-6631-11e7-9609-8e7e7a90da9f.png">

Resulting covering letter, "Inherited pension pot"

<img width="542" alt="screen shot 2017-07-11 at 12 05 13" src="https://user-images.githubusercontent.com/9943/28065750-eaccd63c-6631-11e7-9332-736d5dac20f1.png">
