### PR TITLE
Run migrations upon release

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: bin/puma -C config/puma.rb
 worker: bin/sidekiq -C config/sidekiq.yml
+release: bundle exec rails db:migrate


### PR DESCRIPTION
Take advantage of Heroku's release phase to run migrations
automatically.