### PR TITLE
Remove GTM snippet

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,19 +5,6 @@
 <% content_for :app_title, 'Summary Document Generator' %>
 <% content_for :page_title, title %>
 
-<% content_for :exclude_analytics, true %>
-<% content_for :body_start do %>
-  <!-- Google Tag Manager -->
-  <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-5ZZXFV"
-                    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','GTM-5ZZXFV');</script>
-  <!-- End Google Tag Manager -->
-<% end %>
-
 <% if user_signed_in? %>
   <%= content_for :navbar_right do %>
     <div class='session-details-panel'>


### PR DESCRIPTION
This is not necessary and was passing potentially sensitive data to GA
via the UA plugin.