### PR TITLE
Allow general purpose guiders to summarise

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   serialize :permissions, Array
 
   TELEPHONE_APPOINTMENT_PERMISSION = 'phone_bookings'.freeze
-  FACE_TO_FACE_PERMISSION = 'signin'.freeze
+  FACE_TO_FACE_PERMISSION = 'face_to_face_bookings'.freeze
 
   deprecated_columns :admin, :first_name, :last_name, :encrypted_password, :sign_in_count, :current_sign_in_at,
                      :last_sign_in_at, :current_sign_in_ip, :last_sign_in_ip, :confirmation_token, :confirmed_at,

--- a/app/views/appointment_summaries/new.html.erb
+++ b/app/views/appointment_summaries/new.html.erb
@@ -1,4 +1,6 @@
 <%= form_for @appointment_summary, url: confirm_appointment_summaries_path, method: :post do |f| %>
+  <%= f.hidden_field :telephone_appointment %>
+
   <div class="page-header">
     <h1><%= title 'Create summary document' %></h1>
   </div>
@@ -19,18 +21,18 @@
 
       <div class="form-group">
         <%= f.label :first_name %>
-        <%= f.text_field :first_name, class: %w(form-control input-md-3 t-first-name), readonly: telephone_appointment? %>
+        <%= f.text_field :first_name, class: %w(form-control input-md-3 t-first-name), readonly: @appointment_summary.telephone_appointment? %>
       </div>
 
       <div class="form-group">
         <%= f.label :last_name %>
-        <%= f.text_field :last_name, class: %w(form-control input-md-3 t-last-name), readonly: telephone_appointment? %>
+        <%= f.text_field :last_name, class: %w(form-control input-md-3 t-last-name), readonly: @appointment_summary.telephone_appointment? %>
       </div>
 
       <div class="form-group">
         <%= f.label :email %>
         <div class="email-outer input-md-3">
-          <%= f.email_field :email, class: %w(form-control js-email-validation t-email), readonly: telephone_appointment?, data: email_validation_data_attributes %>
+          <%= f.email_field :email, class: %w(form-control js-email-validation t-email), readonly: @appointment_summary.telephone_appointment?, data: email_validation_data_attributes %>
         </div>
       </div>
 
@@ -76,12 +78,12 @@
       <div class="form-group">
         <%= f.label :date_of_appointment %>
         <%= f.date_field :date_of_appointment,
-                         class: %w(form-control input-md-2 t-date-of-appointment), readonly: telephone_appointment? %>
+                         class: %w(form-control input-md-2 t-date-of-appointment), readonly: @appointment_summary.telephone_appointment? %>
       </div>
 
       <div class="form-group">
         <%= f.label :reference_number %>
-        <%= f.text_field :reference_number, class: %w(form-control input-md-2 t-reference-number), readonly: telephone_appointment? %>
+        <%= f.text_field :reference_number, class: %w(form-control input-md-2 t-reference-number), readonly: @appointment_summary.telephone_appointment? %>
       </div>
 
       <div class="form-group">
@@ -91,13 +93,13 @@
           </legend>
           <div class="radio">
             <%= f.label :appointment_type, value: 'standard' do %>
-              <%= f.radio_button :appointment_type, 'standard', class: 't-appointment-type-standard', disabled: telephone_appointment? %>
+              <%= f.radio_button :appointment_type, 'standard', class: 't-appointment-type-standard', disabled: @appointment_summary.telephone_appointment? %>
               For customers aged 55 or over
             <% end %>
           </div>
           <div class="radio">
             <%= f.label :appointment_type, value: '50_54' do %>
-              <%= f.radio_button :appointment_type, '50_54', class: 't-appointment-type-50-54', disabled: telephone_appointment? %>
+              <%= f.radio_button :appointment_type, '50_54', class: 't-appointment-type-50-54', disabled: @appointment_summary.telephone_appointment? %>
               For customers aged 50 to 54
             <% end %>
           </div>
@@ -201,7 +203,7 @@
 
       <div class="form-group">
         <%= f.label :guider_name %>
-        <%= f.text_field :guider_name, class: %w(form-control input-md-3 t-guider-name), readonly: telephone_appointment? %>
+        <%= f.text_field :guider_name, class: %w(form-control input-md-3 t-guider-name), readonly: @appointment_summary.telephone_appointment? %>
       </div>
 
       <hr>

--- a/spec/controllers/appointment_summaries_controller_spec.rb
+++ b/spec/controllers/appointment_summaries_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe AppointmentSummariesController, 'GET #new', type: :controller do
   let(:email) { 'guider@example.com' }
-  let(:user) { create(:user, email: email) }
+  let(:user) { create(:user, :face_to_face_guider, email: email) }
   let(:warden) { double('stub warden', authenticate!: true, authenticated?: true, user: user) }
 
   subject { response }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -21,6 +21,10 @@ FactoryBot.define do
     trait :face_to_face_guider do
       permissions %w(signin face_to_face_bookings)
     end
+
+    trait :general_guider do
+      permissions %w(signin phone_bookings face_to_face_bookings)
+    end
   end
 
   factory :appointment_summary do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -11,11 +11,15 @@ FactoryBot.define do
     end
 
     trait :team_leader do
-      permissions %w(signin team_leader)
+      permissions %w(signin team_leader face_to_face_bookings)
     end
 
     trait :phone_guider do
       permissions %w(signin phone_bookings)
+    end
+
+    trait :face_to_face_guider do
+      permissions %w(signin face_to_face_bookings)
     end
   end
 

--- a/spec/features/email_address_suggestions_spec.rb
+++ b/spec/features/email_address_suggestions_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature 'Mailgun email verification service suggestions', js: true do
   end
 
   def given_i_am_logged_in_as_a_face_to_face_guider
-    create(:user)
+    create(:user, :face_to_face_guider)
   end
 
   def and_i_am_on_the_summary_form

--- a/spec/features/face_to_face_summary_creation_spec.rb
+++ b/spec/features/face_to_face_summary_creation_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'Face to face guider summary creation' do
 end
 
 def given_i_am_logged_in_as_a_face_to_face_guider
-  create(:user)
+  create(:user, :face_to_face_guider)
 end
 
 def when_i_load_the_blank_summary_form

--- a/spec/features/face_to_face_summary_creation_spec.rb
+++ b/spec/features/face_to_face_summary_creation_spec.rb
@@ -1,9 +1,18 @@
 require 'rails_helper'
 
-RSpec.feature 'Face to face guider summary creation' do
+RSpec.feature 'Face to face appointment summary creation' do
   before { ActiveJob::Base.queue_adapter.enqueued_jobs.clear }
 
-  scenario 'creating a summary' do
+  scenario 'As a general guider' do
+    given_i_am_logged_in_as_a_general_guider
+    when_i_load_the_blank_summary_form
+    and_i_complete_the_summary_form_with_preset_digital_delivery_data
+    then_i_am_able_to_submit_and_confirm_successfully
+    and_the_customer_should_be_notified_by_email
+    and_no_activity_should_be_created_on_tap
+  end
+
+  scenario 'As a face to face guider' do
     given_i_am_logged_in_as_a_face_to_face_guider
     when_i_load_the_blank_summary_form
     and_i_complete_the_summary_form_with_preset_digital_delivery_data
@@ -15,6 +24,10 @@ end
 
 def given_i_am_logged_in_as_a_face_to_face_guider
   create(:user, :face_to_face_guider)
+end
+
+def given_i_am_logged_in_as_a_general_guider
+  create(:user, :general_guider)
 end
 
 def when_i_load_the_blank_summary_form

--- a/spec/features/phone_summary_creation_spec.rb
+++ b/spec/features/phone_summary_creation_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
-RSpec.feature 'Phone guider summary creation' do
+RSpec.feature 'Phone summary creation' do
   before { ActiveJob::Base.queue_adapter.enqueued_jobs.clear }
 
-  scenario 'attempting to create a summary from scratch' do
+  scenario 'Attempting to create a summary from scratch' do
     given_i_am_logged_in_as_a_phone_guider
     when_i_attempt_to_load_the_blank_summary_form
     then_i_am_told_to_use_tap
   end
 
-  scenario 'creating a summary with existing data' do
+  scenario 'Phone guider creates a summary via TAP' do
     given_i_am_logged_in_as_a_phone_guider
     when_i_complete_the_summary_form_with_preset_digital_delivery_data
     and_i_fill_in_the_remaining_details
@@ -17,6 +17,19 @@ RSpec.feature 'Phone guider summary creation' do
     and_the_activity_should_be_created_on_tap
     and_the_customer_should_be_notified_by_email
   end
+
+  scenario 'General purpose guider creates a summary via TAP' do
+    given_i_am_logged_in_as_a_general_guider
+    when_i_complete_the_summary_form_with_preset_digital_delivery_data
+    and_i_fill_in_the_remaining_details
+    then_i_am_able_to_submit_and_confirm_successfully
+    and_the_activity_should_be_created_on_tap
+    and_the_customer_should_be_notified_by_email
+  end
+end
+
+def given_i_am_logged_in_as_a_general_guider
+  @user = create(:user, :general_guider)
 end
 
 def given_i_am_logged_in_as_a_phone_guider

--- a/spec/support/pages/appointment_summary_page.rb
+++ b/spec/support/pages/appointment_summary_page.rb
@@ -67,7 +67,7 @@ class AppointmentSummaryPage < SitePrism::Page
     end
   end
 
-  def params(appointment_summary)
+  def params(appointment_summary) # rubocop:disable MethodLength
     params_from_tap = %i(
       appointment_type
       date_of_appointment
@@ -83,6 +83,8 @@ class AppointmentSummaryPage < SitePrism::Page
       params_from_tap.each do |param|
         params["appointment_summary[#{param}]"] = appointment_summary[param]
       end
+
+      params['appointment_summary[telephone_appointment]'] = 'true'
     end
   end
 


### PR DESCRIPTION
This allows both types of guiders (face-to-face or telephone) to summarise
appointments with the same signon account.