### PR TITLE
Correct issue with disabled/readonly field

### DIFF
--- a/app/views/appointment_summaries/new.html.erb
+++ b/app/views/appointment_summaries/new.html.erb
@@ -93,13 +93,13 @@
           </legend>
           <div class="radio">
             <%= f.label :appointment_type, value: 'standard' do %>
-              <%= f.radio_button :appointment_type, 'standard', class: 't-appointment-type-standard', disabled: @appointment_summary.telephone_appointment? %>
+              <%= f.radio_button :appointment_type, 'standard', class: 't-appointment-type-standard', readonly: @appointment_summary.telephone_appointment? %>
               For customers aged 55 or over
             <% end %>
           </div>
           <div class="radio">
             <%= f.label :appointment_type, value: '50_54' do %>
-              <%= f.radio_button :appointment_type, '50_54', class: 't-appointment-type-50-54', disabled: @appointment_summary.telephone_appointment? %>
+              <%= f.radio_button :appointment_type, '50_54', class: 't-appointment-type-50-54', readonly: @appointment_summary.telephone_appointment? %>
               For customers aged 50 to 54
             <% end %>
           </div>

--- a/spec/features/face_to_face_summary_creation_spec.rb
+++ b/spec/features/face_to_face_summary_creation_spec.rb
@@ -20,40 +20,40 @@ RSpec.feature 'Face to face appointment summary creation' do
     and_the_customer_should_be_notified_by_email
     and_no_activity_should_be_created_on_tap
   end
-end
 
-def given_i_am_logged_in_as_a_face_to_face_guider
-  create(:user, :face_to_face_guider)
-end
+  def given_i_am_logged_in_as_a_face_to_face_guider
+    create(:user, :face_to_face_guider)
+  end
 
-def given_i_am_logged_in_as_a_general_guider
-  create(:user, :general_guider)
-end
+  def given_i_am_logged_in_as_a_general_guider
+    create(:user, :general_guider)
+  end
 
-def when_i_load_the_blank_summary_form
-  @appointment_summary_page = AppointmentSummaryPage.new
-  @appointment_summary_page.load
-end
+  def when_i_load_the_blank_summary_form
+    @appointment_summary_page = AppointmentSummaryPage.new
+    @appointment_summary_page.load
+  end
 
-def and_i_complete_the_summary_form_with_preset_digital_delivery_data
-  template = build(:populated_appointment_summary, :requested_digital)
-  @appointment_summary_page.fill_in(template, face_to_face: true)
-end
+  def and_i_complete_the_summary_form_with_preset_digital_delivery_data
+    template = build(:populated_appointment_summary, :requested_digital)
+    @appointment_summary_page.fill_in(template, face_to_face: true)
+  end
 
-def then_i_am_able_to_submit_and_confirm_successfully
-  @appointment_summary_page.submit.click
+  def then_i_am_able_to_submit_and_confirm_successfully
+    @appointment_summary_page.submit.click
 
-  @confirmation_page = ConfirmationPage.new
-  @confirmation_page.confirm.click
+    @confirmation_page = ConfirmationPage.new
+    @confirmation_page.confirm.click
 
-  @done_page = DonePage.new
-  expect(@done_page).to be_displayed
-end
+    @done_page = DonePage.new
+    expect(@done_page).to be_displayed
+  end
 
-def and_the_customer_should_be_notified_by_email
-  assert_enqueued_jobs 1, only: NotifyViaEmail
-end
+  def and_the_customer_should_be_notified_by_email
+    assert_enqueued_jobs 1, only: NotifyViaEmail
+  end
 
-def and_no_activity_should_be_created_on_tap
-  assert_enqueued_jobs 0, only: CreateTapActivity
+  def and_no_activity_should_be_created_on_tap
+    assert_enqueued_jobs 0, only: CreateTapActivity
+  end
 end

--- a/spec/features/phone_summary_creation_spec.rb
+++ b/spec/features/phone_summary_creation_spec.rb
@@ -26,50 +26,52 @@ RSpec.feature 'Phone summary creation' do
     and_the_activity_should_be_created_on_tap
     and_the_customer_should_be_notified_by_email
   end
-end
 
-def given_i_am_logged_in_as_a_general_guider
-  @user = create(:user, :general_guider)
-end
+  def given_i_am_logged_in_as_a_general_guider
+    @user = create(:user, :general_guider)
+  end
 
-def given_i_am_logged_in_as_a_phone_guider
-  @user = create(:user, :phone_guider)
-end
+  def given_i_am_logged_in_as_a_phone_guider
+    @user = create(:user, :phone_guider)
+  end
 
-def when_i_attempt_to_load_the_blank_summary_form
-  @appointment_summary_page = AppointmentSummaryPage.new
-  @appointment_summary_page.load
-end
+  def when_i_attempt_to_load_the_blank_summary_form
+    @appointment_summary_page = AppointmentSummaryPage.new
+    @appointment_summary_page.load
+  end
 
-def when_i_complete_the_summary_form_with_preset_digital_delivery_data
-  @appointment_summary_template = build(:populated_appointment_summary, :requested_digital)
+  def when_i_complete_the_summary_form_with_preset_digital_delivery_data
+    @appointment_summary_template = build(:populated_appointment_summary, :requested_digital, appointment_type: '50_54')
 
-  @appointment_summary_page = AppointmentSummaryPage.new
-  @appointment_summary_page.load(@appointment_summary_template)
-end
+    @appointment_summary_page = AppointmentSummaryPage.new
+    @appointment_summary_page.load(@appointment_summary_template)
+  end
 
-def and_i_fill_in_the_remaining_details
-  @appointment_summary_page.fill_in(@appointment_summary_template)
-end
+  def and_i_fill_in_the_remaining_details
+    @appointment_summary_page.fill_in(@appointment_summary_template)
+  end
 
-def then_i_am_told_to_use_tap
-  expect(@appointment_summary_page).to have_use_tap_warning
-end
+  def then_i_am_told_to_use_tap
+    expect(@appointment_summary_page).to have_use_tap_warning
+  end
 
-def then_i_am_able_to_submit_and_confirm_successfully
-  @appointment_summary_page.submit.click
+  def then_i_am_able_to_submit_and_confirm_successfully
+    @appointment_summary_page.submit.click
 
-  @confirmation_page = ConfirmationPage.new
-  @confirmation_page.confirm.click
+    @confirmation_page = ConfirmationPage.new
+    @confirmation_page.confirm.click
 
-  @done_page = DonePage.new
-  expect(@done_page).to be_displayed
-end
+    @done_page = DonePage.new
+    expect(@done_page).to be_displayed
 
-def and_the_activity_should_be_created_on_tap
-  assert_enqueued_jobs 1, only: CreateTapActivity
-end
+    expect(AppointmentSummary.last.appointment_type).to eq('50_54')
+  end
 
-def and_the_customer_should_be_notified_by_email
-  assert_enqueued_jobs 1, only: NotifyViaEmail
+  def and_the_activity_should_be_created_on_tap
+    assert_enqueued_jobs 1, only: CreateTapActivity
+  end
+
+  def and_the_customer_should_be_notified_by_email
+    assert_enqueued_jobs 1, only: NotifyViaEmail
+  end
 end


### PR DESCRIPTION
When the field is marked with the `disabled` attribute it does not POST
a value, thus would be preselected as `standard` for the
`appointment_type`. This means some customers were missing out on vital
information pertaining to the pensionable age.

I also scoped the test helper methods as they were clobbering eachother
in the global namespace.