### PR TITLE
Validate email presence when requesting digital

### DIFF
--- a/app/models/appointment_summary.rb
+++ b/app/models/appointment_summary.rb
@@ -73,6 +73,7 @@ class AppointmentSummary < ApplicationRecord # rubocop:disable ClassLength
   validates :covering_letter_type, inclusion: { in: %w(section_32 adjustable_income inherited_pot) }, allow_blank: true
   validates :number_of_previous_appointments, inclusion: { in: 0..3 }
   validates :email, format: EMAIL_REGEXP
+  validates :email, presence: true, if: :requested_digital?
   validates :telephone_appointment, inclusion: { in: [true, false] }
 
   def self.editable_column_names

--- a/spec/controllers/appointment_summaries_controller_spec.rb
+++ b/spec/controllers/appointment_summaries_controller_spec.rb
@@ -43,7 +43,9 @@ RSpec.describe AppointmentSummariesController, 'GET #new', type: :controller do
         it 'we should not attempt to notify the customer' do
           expect(NotifyViaEmail).not_to receive(:perform_later)
 
-          post :create, params: { appointment_summary: appointment_summary }
+          expect do
+            post :create, params: { appointment_summary: appointment_summary }
+          end.to raise_error(ActiveRecord::RecordInvalid)
         end
       end
     end

--- a/spec/models/appointment_summary_spec.rb
+++ b/spec/models/appointment_summary_spec.rb
@@ -59,17 +59,20 @@ RSpec.describe AppointmentSummary, type: :model do
     it { is_expected.not_to allow_value('fr@ed@spaced..com').for(:email) }
     it { is_expected.not_to allow_value('"fred"@spaced.com').for(:email) }
     it { is_expected.not_to allow_value('fred;jones@spaced.com').for(:email) }
-    it { is_expected.to allow_value('').for(:email) }
   end
 
   context 'requested_digital is true' do
     before { subject.requested_digital = true }
     include_examples 'it is a valid email'
+
+    it { is_expected.not_to allow_value('').for(:email) }
   end
 
   context 'requested_digital is false' do
     before { subject.requested_digital = false }
     include_examples 'it is a valid email'
+
+    it { is_expected.to allow_value('').for(:email) }
   end
 
   describe '#country' do


### PR DESCRIPTION
Digital summaries should not be created when no email address was
specified.