### PR TITLE
Ensure f2f/phone appointments are distinct

### DIFF
--- a/app/controllers/appointment_summaries_controller.rb
+++ b/app/controllers/appointment_summaries_controller.rb
@@ -81,7 +81,8 @@ class AppointmentSummariesController < ApplicationController
 
   def load_summary
     @appointment_summary = AppointmentSummary.find_or_initialize_by(
-      reference_number: params.dig(:appointment_summary, :reference_number)
+      reference_number: params.dig(:appointment_summary, :reference_number),
+      telephone_appointment: telephone_appointment?
     )
   end
 


### PR DESCRIPTION
Previously if appointments had the same ID (rare but possible) they
could be linked incorrectly. This ensures that will not happen.