### PR TITLE
Work around missing users

### DIFF
--- a/app/models/appointment_summary.rb
+++ b/app/models/appointment_summary.rb
@@ -119,7 +119,7 @@ class AppointmentSummary < ApplicationRecord # rubocop:disable ClassLength
   end
 
   def organisation_id
-    user.organisation_content_id
+    user&.organisation_content_id
   end
 
   def supplementary_info_selected?


### PR DESCRIPTION
There are some instances of old data where the associated user is
missing or not synchronised from signon. This ensures the organisation
ID is accessed safely in those instances.