### PR TITLE
Update output templates for signposting

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/guidance-guarantee-programme/output-templates.git
-  revision: 7033e8c8153924840ad38e619386612ca29f7488
+  revision: ee6bc32be91a08b0cb7b3bb51476658fe5ba73ef
   specs:
-    output-templates (4.13.0)
+    output-templates (4.14.0)
       actionview
       sass
 
@@ -65,7 +65,7 @@ GEM
       sass (>= 3.3.0)
     bugsnag (6.7.3)
       concurrent-ruby (~> 1.0)
-    builder (3.2.3)
+    builder (3.2.4)
     byebug (10.0.2)
     capybara (3.12.0)
       addressable
@@ -85,7 +85,7 @@ GEM
     deprecated_columns (0.1.1)
       rails (>= 4.0)
     diff-lcs (1.3)
-    erubi (1.8.0)
+    erubi (1.9.0)
     execjs (2.7.0)
     factory_bot (4.10.0)
       activesupport (>= 3.0.0)
@@ -138,7 +138,7 @@ GEM
     kaminari-core (1.1.1)
     launchy (2.4.3)
       addressable (~> 2.3)
-    loofah (2.3.1)
+    loofah (2.4.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -148,7 +148,7 @@ GEM
     method_source (0.9.2)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
-    minitest (5.11.3)
+    minitest (5.13.0)
     msgpack (1.2.4)
     multi_json (1.13.1)
     multi_xml (0.6.0)
@@ -158,7 +158,7 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (5.0.2)
     nio4r (2.3.1)
-    nokogiri (1.10.5)
+    nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
     notifications-ruby-client (2.6.0)
       jwt (>= 1.5, < 3)
@@ -217,8 +217,8 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.0.4)
-      loofah (~> 2.2, >= 2.2.2)
+    rails-html-sanitizer (1.3.0)
+      loofah (~> 2.3)
     rails-i18n (5.0.4)
       i18n (~> 0.7)
       railties (~> 5.0)


### PR DESCRIPTION
A calculator was inaccurate so was replaced by MAS. This update ensures
we point to the correct version.