### PR TITLE
Provide a simple search API for appointments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby IO.read('.ruby-version').strip
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
 source 'https://rubygems.org' do # rubocop:disable Metrics/BlockLength
+  gem 'active_model_serializers'
   gem 'autoprefixer-rails'
   gem 'bootsnap', require: false
   gem 'bootstrap-kaminari-views'

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ source 'https://rubygems.org' do # rubocop:disable Metrics/BlockLength
   gem 'plek'
   gem 'princely'
   gem 'puma'
+  gem 'rack-cors'
   gem 'rails', '~> 5.1.6'
   gem 'rails-i18n', '~> 5.0.0'
   gem 'retriable'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_model_serializers (0.10.10)
+      actionpack (>= 4.1, < 6.1)
+      activemodel (>= 4.1, < 6.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (5.1.6.2)
       activesupport (= 5.1.6.2)
       globalid (>= 0.3.6)
@@ -74,6 +79,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.2)
       xpath (~> 3.2)
+    case_transform (0.2)
+      activesupport
     cliver (0.3.2)
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
@@ -122,6 +129,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jsonapi-renderer (0.2.2)
     jwt (1.5.6)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
@@ -337,6 +345,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers!
   autoprefixer-rails!
   bootsnap!
   bootstrap-kaminari-views!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,6 +204,8 @@ GEM
     public_suffix (3.0.3)
     puma (3.12.2)
     rack (2.0.6)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-protection (2.0.3)
       rack
     rack-test (1.1.0)
@@ -372,6 +374,7 @@ DEPENDENCIES
   princely!
   pry-byebug!
   puma!
+  rack-cors!
   rails (~> 5.1.6)!
   rails-i18n (~> 5.0.0)!
   rails_12factor!

--- a/app/controllers/api/v1/searches_controller.rb
+++ b/app/controllers/api/v1/searches_controller.rb
@@ -1,0 +1,15 @@
+module Api
+  module V1
+    class SearchesController < ActionController::Base
+      include GDS::SSO::ControllerMethods
+
+      before_action { authorise_user!(User::API_USER_PERMISSION) }
+
+      def index
+        @results = AppointmentSummarySearch.new(params[:query]).call
+
+        render json: @results
+      end
+    end
+  end
+end

--- a/app/models/appointment_summary_search.rb
+++ b/app/models/appointment_summary_search.rb
@@ -1,0 +1,23 @@
+class AppointmentSummarySearch
+  def initialize(query)
+    @query = query
+  end
+
+  def call
+    return [] if query.blank?
+    return search_by_reference if /\A\d+\Z/.match?(query.to_s)
+
+    AppointmentSummary
+      .where('last_name ILIKE :query OR email ILIKE :query', query: "%#{query}%")
+      .order(created_at: :desc)
+      .limit(20)
+  end
+
+  private
+
+  attr_reader :query
+
+  def search_by_reference
+    AppointmentSummary.where(reference_number: query)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
 
   TELEPHONE_APPOINTMENT_PERMISSION = 'phone_bookings'.freeze
   FACE_TO_FACE_PERMISSION = 'face_to_face_bookings'.freeze
+  API_USER_PERMISSION = 'api_user'.freeze
 
   deprecated_columns :admin, :first_name, :last_name, :encrypted_password, :sign_in_count, :current_sign_in_at,
                      :last_sign_in_at, :current_sign_in_ip, :last_sign_in_ip, :confirmation_token, :confirmed_at,

--- a/app/serializers/appointment_summary_serializer.rb
+++ b/app/serializers/appointment_summary_serializer.rb
@@ -1,0 +1,10 @@
+class AppointmentSummarySerializer < ActiveModel::Serializer
+  include Rails.application.routes.url_helpers
+
+  attribute :reference_number, key: :reference
+  attribute :full_name, key: :name
+
+  attribute :url do
+    edit_admin_appointment_summary_url(object)
+  end
+end

--- a/app/serializers/appointment_summary_serializer.rb
+++ b/app/serializers/appointment_summary_serializer.rb
@@ -7,4 +7,8 @@ class AppointmentSummarySerializer < ActiveModel::Serializer
   attribute :url do
     edit_admin_appointment_summary_url(object)
   end
+
+  attribute :application do
+    'Summary Document Generator'
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,5 +14,12 @@ module Output
   class Application < Rails::Application
     config.action_mailer.default_url_options = { host: ENV['APPLICATION_HOST'] }
     config.active_job.queue_adapter = :sidekiq
+
+    config.middleware.insert_before 0, Rack::Cors do
+      allow do
+        origins '*'
+        resource '/api/v1/searches', headers: :any, methods: %i(get options)
+      end
+    end
   end
 end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,3 +3,5 @@ require_relative 'application'
 
 # Initialize the Rails application.
 Rails.application.initialize!
+
+Rails.application.default_url_options = Rails.application.config.action_mailer.default_url_options

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,4 +55,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  #
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3001 }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -70,6 +70,8 @@ Rails.application.configure do # rubocop:disable Metrics/BlockLength
   # Configure email delivery method
   config.action_mailer.delivery_method = :smtp
 
+  config.action_mailer.default_url_options = { host: ENV['APPLICATION_HOST'] }
+
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -34,6 +34,8 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3001 }
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 

--- a/config/initializers/gds_sso.rb
+++ b/config/initializers/gds_sso.rb
@@ -5,5 +5,7 @@ GDS::SSO.config do |config|
   config.oauth_root_url = ENV['OAUTH_ROOT_URL']
   config.oauth_secret = ENV['OAUTH_SECRET']
 
+  config.additional_mock_permissions_required = [User::API_USER_PERMISSION]
+
   config.cache = Rails.cache
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,12 @@ Rails.application.routes.draw do
   mount GovukAdminTemplate::Engine, at: '/style-guide'
   mount Sidekiq::Web => '/sidekiq', constraints: AuthenticatedUser.new
 
+  namespace :api, constraints: { format: :json } do
+    namespace :v1 do
+      resources :searches, only: :index
+    end
+  end
+
   resources :appointment_summaries, only: %i(index new create update show) do
     collection do
       get :creating

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -6,6 +6,10 @@ FactoryBot.define do
     name 'Rick Sanchez'
     permissions %w(signin)
 
+    trait :api_user do
+      permissions %w(signin api_user)
+    end
+
     trait :analyst do
       permissions %w(signin analyst)
     end

--- a/spec/models/appointment_summary_search_spec.rb
+++ b/spec/models/appointment_summary_search_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe AppointmentSummarySearch do
+  context 'with a blank query' do
+    it 'returns an empty array' do
+      expect(described_class.new('').call).to eq([])
+    end
+  end
+
+  context 'with a reference number' do
+    it 'returns the matching result' do
+      @appointment = create(:appointment_summary)
+
+      expect(described_class.new(@appointment.reference_number).call).to eq([@appointment])
+    end
+  end
+
+  context 'with a name or email' do
+    it 'returns the matching results' do
+      @appointment = create(:appointment_summary, last_name: 'Jones')
+      @other       = create(:appointment_summary, email: 'bleh@example.com')
+
+      # by name
+      expect(described_class.new('jones').call).to eq([@appointment])
+      # by email
+      expect(described_class.new('bleh@exam').call).to eq([@other])
+    end
+  end
+end

--- a/spec/requests/api_searches_spec.rb
+++ b/spec/requests/api_searches_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe 'GET /api/v1/searches' do
     expect(results.first).to eq(
       'reference' => @appointment.reference_number,
       'name' => @appointment.full_name,
-      'url' => "http://localhost:3001/admin/appointment_summaries/#{@appointment.id}/edit"
+      'url' => "http://localhost:3001/admin/appointment_summaries/#{@appointment.id}/edit",
+      'application' => 'Summary Document Generator'
     )
   end
 

--- a/spec/requests/api_searches_spec.rb
+++ b/spec/requests/api_searches_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /api/v1/searches' do
+  scenario 'searching for appointment summaries' do
+    given_an_api_user do
+      and_an_appointment_matching_the_search_criteria_exists
+      when_a_valid_search_is_made
+      then_the_service_responds_ok
+      and_the_results_are_serialized_as_json
+    end
+  end
+
+  scenario 'unauthorized access' do
+    given_a_user do
+      when_an_unauthorized_request_is_made
+      then_the_service_responds_with_a_403_status
+    end
+  end
+
+  def when_a_valid_search_is_made
+    get api_v1_searches_path, params: { query: 'ben@example.com' }, as: :json
+  end
+
+  def and_an_appointment_matching_the_search_criteria_exists
+    @appointment = create(:appointment_summary, email: 'ben@example.com')
+  end
+
+  def then_the_service_responds_ok
+    expect(response).to be_ok
+  end
+
+  def and_the_results_are_serialized_as_json
+    results = JSON.parse(response.body)
+
+    expect(results.first).to eq(
+      'reference' => @appointment.reference_number,
+      'name' => @appointment.full_name,
+      'url' => "http://localhost:3001/admin/appointment_summaries/#{@appointment.id}/edit"
+    )
+  end
+
+  def when_an_unauthorized_request_is_made
+    get api_v1_searches_path
+  end
+
+  def then_the_service_responds_with_a_403_status
+    expect(response).to be_forbidden
+  end
+end

--- a/spec/support/user_helpers.rb
+++ b/spec/support/user_helpers.rb
@@ -8,6 +8,13 @@ module UserHelpers
     ENV['GDS_SSO_MOCK_INVALID'] = sso_env
   end
 
+  def given_an_api_user
+    GDS::SSO.test_user = create(:user, :api_user)
+    yield
+  ensure
+    GDS::SSO.test_user = nil
+  end
+
   def given_a_user
     GDS::SSO.test_user = create(:user)
     yield


### PR DESCRIPTION
When provided with a query (reference or partial match on name/email) we
return the appointments matching the given critera. The attributes:
reference, name and URL are serialized and returned as JSON.