### PR TITLE
Script redactions for GDPR compliance

### DIFF
--- a/app/models/appointment_summary.rb
+++ b/app/models/appointment_summary.rb
@@ -78,6 +78,12 @@ class AppointmentSummary < ApplicationRecord # rubocop:disable ClassLength
   validates :email, presence: true, if: :requested_digital?
   validates :telephone_appointment, inclusion: { in: [true, false] }
 
+  def self.for_redaction
+    where
+      .not(first_name: Redactor::REDACTED)
+      .where('created_at < ?', 2.years.ago.beginning_of_day)
+  end
+
   def self.editable_column_names
     column_names - %w(id created_at updated_at user_id notification_id)
   end

--- a/app/services/redactor.rb
+++ b/app/services/redactor.rb
@@ -1,0 +1,43 @@
+class Redactor
+  REDACTED = 'REDACTED'.freeze
+
+  def initialize(reference)
+    @reference = reference
+  end
+
+  def call
+    return unless appointment_summary = AppointmentSummary.find(reference) # rubocop:disable AssignmentInCondition
+
+    ActiveRecord::Base.transaction do
+      appointment_summary.assign_attributes(redacted_attributes)
+      appointment_summary.save(validate: false)
+    end
+  end
+
+  def self.redact_for_gdpr
+    AppointmentSummary.for_redaction.pluck(:id).each do |reference|
+      new(reference).call
+    end
+  end
+
+  private
+
+  def redacted_attributes
+    {
+      title: '',
+      first_name: REDACTED,
+      last_name: REDACTED,
+      value_of_pension_pots: 0,
+      upper_value_of_pension_pots: 0,
+      address_line_1: REDACTED,
+      address_line_2: REDACTED,
+      address_line_3: REDACTED,
+      town: REDACTED,
+      county: REDACTED,
+      postcode: REDACTED,
+      email: REDACTED
+    }
+  end
+
+  attr_reader :reference
+end

--- a/lib/tasks/confidentiality.rake
+++ b/lib/tasks/confidentiality.rake
@@ -1,32 +1,13 @@
-namespace :confidentiality do # rubocop:disable BlockLength
-  desc 'Redact customer details (REFERENCE=x TELEPHONE=true)'
+namespace :confidentiality do
+  desc 'Redact customer details (REFERENCE=id)'
   task redact: :environment do
-    reference   = ENV.fetch('REFERENCE')
-    telephone   = ENV.fetch('TELEPHONE') { false }
-    appointment = AppointmentSummary.find_by(reference_number: reference, telephone_appointment: telephone)
-    REDACTED    = 'REDACTED'.freeze
+    reference = ENV.fetch('REFERENCE')
 
-    if appointment
-      appointment.assign_attributes(
-        title: '',
-        first_name: REDACTED,
-        last_name: REDACTED,
-        value_of_pension_pots: 0,
-        upper_value_of_pension_pots: 0,
-        address_line_1: REDACTED,
-        address_line_2: REDACTED,
-        address_line_3: REDACTED,
-        town: REDACTED,
-        county: REDACTED,
-        postcode: REDACTED,
-        email: REDACTED
-      )
+    Redactor.new(reference).call
+  end
 
-      appointment.save(validate: false)
-
-      puts 'The appointment summary was redacted'
-    else
-      puts 'Nothing found for the given `REFERENCE`'
-    end
+  desc 'Redact records greater than 2 years old for GDPR'
+  task gdpr: :environment do
+    Redactor.redact_for_gdpr
   end
 end

--- a/spec/services/redactor_spec.rb
+++ b/spec/services/redactor_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe Redactor do
+  include ActiveSupport::Testing::TimeHelpers
+
+  describe '.redact_for_gdpr' do
+    it 'redacts records yet to be redacted, greater than 2 years old' do
+      travel_to '2018-02-28 10:00' do
+        @redacted = create(:appointment_summary, first_name: Redactor::REDACTED)
+        @included = create(:appointment_summary)
+      end
+
+      travel_to '2020-01-01 10:00' do
+        @excluded = create(:appointment_summary)
+      end
+
+      travel_to '2020-03-31 10:00' do
+        described_class.redact_for_gdpr
+      end
+
+      # was redacted
+      expect(@included.reload.created_at).not_to eq(@included.updated_at)
+      # was already redacted so not updated
+      expect(@redacted.reload.created_at).to eq(@redacted.updated_at)
+      # was outside the date range so not updated
+      expect(@excluded.reload.created_at).to eq(@excluded.updated_at)
+    end
+  end
+
+  describe '#call' do
+    it 'redacts all personally identifying information' do
+      summary     = create(:appointment_summary)
+      redactor    = described_class.new(summary.id)
+
+      redactor.call
+
+      expect(summary.reload).to have_attributes(
+        title: '',
+        first_name: Redactor::REDACTED,
+        last_name: Redactor::REDACTED,
+        value_of_pension_pots: 0,
+        upper_value_of_pension_pots: 0,
+        address_line_1: Redactor::REDACTED,
+        address_line_2: Redactor::REDACTED,
+        address_line_3: Redactor::REDACTED,
+        town: Redactor::REDACTED,
+        county: Redactor::REDACTED,
+        postcode: Redactor::REDACTED,
+        email: Redactor::REDACTED
+      )
+    end
+  end
+end


### PR DESCRIPTION
Can now redact all records older than two years for GDPR compliance.