### PR TITLE
Allow guiders to specify DB pension options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 language: ruby
+addons:
+  chrome: stable
 services:
 - redis-server
 - postgresql
@@ -10,7 +12,6 @@ cache:
   - node_modules
   - tmp/cache/assets/test
   - vendor/assets/bower_components
-  - $HOME/.phantomjs
 env:
   global:
   - secure: ZbggxPXsIVr8W4yO7oLH0Ps+jaCcZcwvR3/wUCjwtaO/FdmHhE8LkN9If14IYyiegEmF4kmlqH03+Svb1CGOgt54kQ4wCuN8dCNH+hGS39Vn/E2ngC/h5U/wf99m4IVzBPzg0IcKN9OWCWzRRMUM+X0Zq04zuekWwUMKlERAajk=

--- a/Gemfile
+++ b/Gemfile
@@ -41,11 +41,11 @@ source 'https://rubygems.org' do # rubocop:disable Metrics/BlockLength
   group :development, :test do
     gem 'database_rewinder'
     gem 'launchy'
-    gem 'phantomjs'
-    gem 'poltergeist'
     gem 'pry-byebug'
     gem 'rspec-rails'
     gem 'scss_lint', require: false
+    gem 'selenium-webdriver'
+    gem 'webdrivers'
   end
 
   group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
       xpath (~> 3.2)
     case_transform (0.2)
       activesupport
-    cliver (0.3.2)
+    childprocess (3.0.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.7)
     connection_pool (2.2.2)
@@ -200,12 +200,7 @@ GEM
     parser (2.5.1.0)
       ast (~> 2.4.0)
     pg (0.21.0)
-    phantomjs (2.1.1.0)
     plek (2.1.1)
-    poltergeist (1.18.1)
-      capybara (>= 2.1, < 4)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     postgres-copy (1.4.1)
       activerecord (>= 5.1)
       pg (>= 0.17)
@@ -294,6 +289,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
+    rubyzip (2.3.0)
     sass (3.5.7)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -313,6 +309,9 @@ GEM
     scss_lint (0.57.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5.5)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
     shoulda-matchers (3.1.2)
       activesupport (>= 4.0.0)
     sidekiq (5.1.3)
@@ -356,6 +355,10 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    webdrivers (4.4.1)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webrick (1.4.2)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
@@ -389,9 +392,7 @@ DEPENDENCIES
   notifications-ruby-client!
   output-templates!
   pg (= 0.21.0)!
-  phantomjs!
   plek!
-  poltergeist!
   postgres-copy!
   princely!
   pry-byebug!
@@ -405,6 +406,7 @@ DEPENDENCIES
   rubocop (= 0.47.1)!
   sassc-rails!
   scss_lint!
+  selenium-webdriver!
   shoulda-matchers!
   sidekiq!
   sinatra!
@@ -413,6 +415,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)!
   uk_postcode!
   web-console (~> 2.0)!
+  webdrivers!
   webrick!
 
 RUBY VERSION

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -5,4 +5,5 @@
 //= require pension-pot-accuracy
 //= require pension-pot-input
 //= require postcode-lookup
+//= require govuk-admin-template/modules/radio_toggle
 //= require init

--- a/app/assets/javascripts/eligibility.js
+++ b/app/assets/javascripts/eligibility.js
@@ -10,7 +10,7 @@
     },
     cache: function () {
       this.$wrapper = $('.display_if_eligible');
-      this.$input = $('input[name="appointment_summary[has_defined_contribution_pension]"]');
+      this.$input = $('input[name="appointment_summary[has_defined_contribution_pension]"], input[name="appointment_summary[considering_transferring_to_dc_pot]"]');
     },
     bindEvents: function () {
       var that = this;

--- a/app/models/appointment_summary.rb
+++ b/app/models/appointment_summary.rb
@@ -111,7 +111,8 @@ class AppointmentSummary < ApplicationRecord # rubocop:disable ClassLength
   end
 
   def eligible_for_guidance?
-    %w(yes unknown).include?(has_defined_contribution_pension)
+    %w(yes unknown).include?(has_defined_contribution_pension) ||
+      has_defined_benefit_pension == 'yes'
   end
 
   def can_be_emailed?

--- a/app/models/appointment_summary.rb
+++ b/app/models/appointment_summary.rb
@@ -68,6 +68,20 @@ class AppointmentSummary < ApplicationRecord # rubocop:disable ClassLength
               message: '%{value} is not a valid value'
             }
 
+  validates :has_defined_benefit_pension,
+            inclusion: {
+              in: %w(yes no),
+              message: '%{value} is not a valid value'
+            },
+            if: -> { has_defined_contribution_pension == 'no' }
+
+  validates :considering_transferring_to_dc_pot,
+            inclusion: {
+              in: %w(yes no),
+              message: '%{value} is not a valid value'
+            },
+            if: -> { has_defined_benefit_pension == 'yes' }
+
   validates :format_preference, inclusion: { in: %w(standard large_text braille) }
   validates :appointment_type, inclusion: { in: %w(standard 50_54) }
   validates :covering_letter_type,

--- a/app/views/appointment_summaries/new.html.erb
+++ b/app/views/appointment_summaries/new.html.erb
@@ -240,7 +240,7 @@
               <div class="form-group" data-module="radio-toggle">
                 <fieldset>
                   <legend>
-                    <span>Does customer have a defined benefit pension?</span>
+                    <span>Does customer have a defined benefit pension only?</span>
                   </legend>
                   <div class="radio">
                     <%= f.label :has_defined_benefit_pension, value: 'yes' do %>

--- a/app/views/appointment_summaries/new.html.erb
+++ b/app/views/appointment_summaries/new.html.erb
@@ -216,7 +216,7 @@
 
       <h2>Pension pot details</h2>
 
-      <div class="form-group">
+      <div class="form-group" data-module="radio-toggle">
         <fieldset>
           <legend>
             <span>Does customer have a defined contribution pension?</span>
@@ -228,12 +228,61 @@
               Yes
             <% end %>
           </div>
-          <div class="radio">
+          <div class="radio" >
             <%= f.label :has_defined_contribution_pension, value: 'no' do %>
               <%= f.radio_button :has_defined_contribution_pension, 'no',
-                                 class: 't-has-defined-contribution-pension-no' %>
+                class: 't-has-defined-contribution-pension-no',
+                data: { target: 'dc-pot-no' } %>
               No
             <% end %>
+
+            <div class="col-xs-offset-1" id="dc-pot-no">
+              <div class="form-group" data-module="radio-toggle">
+                <fieldset>
+                  <legend>
+                    <span>Does customer have a defined contribution pension?</span>
+                  </legend>
+                  <div class="radio">
+                    <%= f.label :has_defined_benefit_pension, value: 'yes' do %>
+                      <%= f.radio_button :has_defined_benefit_pension, 'yes', class: 't-has-defined-benefit-pension-yes', data: { target: 'db-pot-yes' } %>
+                      Yes
+                    <% end %>
+
+                    <div class="col-xs-offset-1" id="db-pot-yes">
+                      <div class="form-group" data-module="radio-toggle">
+                        <fieldset>
+                          <legend>
+                            <span>Is the customer considering transferring out to a DC pot?</span>
+                          </legend>
+                          <div class="radio">
+                            <%= f.label :considering_transferring_to_dc_pot, value: 'yes' do %>
+                              <%= f.radio_button :considering_transferring_to_dc_pot, 'yes', class: 't-considering-transferring-to-dc-pot-yes' %>
+                              Yes
+                            <% end %>
+                          </div>
+
+                          <div class="radio">
+                            <%= f.label :considering_transferring_to_dc_pot, value: 'no' do %>
+                              <%= f.radio_button :considering_transferring_to_dc_pot, 'no', class: 't-considering-transferring-to-dc-pot-no' %>
+                              No
+                            <% end %>
+                          </div>
+                        </fieldset>
+                      </div>
+                    </div>
+
+                  </div>
+
+                  <div class="radio">
+                    <%= f.label :has_defined_benefit_pension, value: 'no' do %>
+                      <%= f.radio_button :has_defined_benefit_pension, 'no', class: 't-has-defined-benefit-pension-no' %>
+                      No
+                    <% end %>
+                  </div>
+                </fieldset>
+              </div>
+            </div>
+
           </div>
           <div class="radio">
             <%= f.label :has_defined_contribution_pension, value: 'unknown' do %>

--- a/app/views/appointment_summaries/new.html.erb
+++ b/app/views/appointment_summaries/new.html.erb
@@ -240,7 +240,7 @@
               <div class="form-group" data-module="radio-toggle">
                 <fieldset>
                   <legend>
-                    <span>Does customer have a defined contribution pension?</span>
+                    <span>Does customer have a defined benefit pension?</span>
                   </legend>
                   <div class="radio">
                     <%= f.label :has_defined_benefit_pension, value: 'yes' do %>
@@ -294,7 +294,7 @@
         </fieldset>
       </div>
 
-      <div class="display_if_eligible">
+      <div class="display_if_eligible" id="display-if-eligible">
         <div class="row">
           <div class="col-md-4" id="col-pension-pot-value">
             <div class="form-group form-inline">

--- a/db/migrate/20201105164411_add_db_pot_attributes_to_appointment_summaries.rb
+++ b/db/migrate/20201105164411_add_db_pot_attributes_to_appointment_summaries.rb
@@ -1,0 +1,6 @@
+class AddDbPotAttributesToAppointmentSummaries < ActiveRecord::Migration[5.1]
+  def change
+    add_column :appointment_summaries, :has_defined_benefit_pension, :string
+    add_column :appointment_summaries, :considering_transferring_to_dc_pot, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170710142023) do
+ActiveRecord::Schema.define(version: 20201105164411) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -52,6 +52,8 @@ ActiveRecord::Schema.define(version: 20170710142023) do
     t.integer "notify_status", default: 0, null: false
     t.boolean "telephone_appointment", default: true
     t.string "covering_letter_type", default: "", null: false
+    t.string "has_defined_benefit_pension"
+    t.string "considering_transferring_to_dc_pot"
     t.index ["user_id"], name: "index_appointment_summaries_on_user_id"
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -56,6 +56,12 @@ FactoryBot.define do
     email 'joe@bloggs.com'
     telephone_appointment true
 
+    trait :has_defined_benefit_pension do
+      has_defined_contribution_pension 'no'
+      has_defined_benefit_pension 'yes'
+      considering_transferring_to_dc_pot 'no'
+    end
+
     factory :notify_delivered_appointment_summary do
       requested_digital true
       notification_id { SecureRandom.uuid }

--- a/spec/features/ineligibility_letter_spec.rb
+++ b/spec/features/ineligibility_letter_spec.rb
@@ -14,7 +14,7 @@ def given_i_am_logged_in_as_a_phone_guider
 end
 
 def and_the_customer_does_not_have_a_defined_contribution_pension_pot
-  @appointment_summary = create(:populated_appointment_summary, has_defined_contribution_pension: 'no')
+  @appointment_summary = create(:populated_appointment_summary, :has_defined_benefit_pension)
 end
 
 def when_they_have_had_a_pension_wise_appointment

--- a/spec/jobs/notify_via_email_spec.rb
+++ b/spec/jobs/notify_via_email_spec.rb
@@ -39,7 +39,9 @@ RSpec.describe NotifyViaEmail do
   end
 
   context 'when the customer does not have a DC pension' do
-    let(:appointment_summary) { create(:appointment_summary, has_defined_contribution_pension: 'no') }
+    let(:appointment_summary) do
+      create(:appointment_summary, :has_defined_benefit_pension)
+    end
 
     it 'sends an ineligible email notification' do
       expect(client).to receive(:send_email).with(

--- a/spec/jobs/notify_via_email_spec.rb
+++ b/spec/jobs/notify_via_email_spec.rb
@@ -43,11 +43,11 @@ RSpec.describe NotifyViaEmail do
       create(:appointment_summary, :has_defined_benefit_pension)
     end
 
-    it 'sends an ineligible email notification' do
+    it 'sends an eligible email notification' do
       expect(client).to receive(:send_email).with(
         {
           email_address: appointment_summary.email,
-          template_id: 'ineligible_template',
+          template_id: 'template',
           personalisation: {
             reference_number: appointment_summary.reference_number,
             title: appointment_summary.title,

--- a/spec/models/appointment_summary_spec.rb
+++ b/spec/models/appointment_summary_spec.rb
@@ -137,6 +137,18 @@ RSpec.describe AppointmentSummary, type: :model do
 
     it { is_expected.to_not validate_numericality_of(:value_of_pension_pots) }
     it { is_expected.to_not validate_numericality_of(:upper_value_of_pension_pots) }
+
+    it 'requires an answer to `has_defined_benefit_pension`' do
+      expect(subject).to validate_inclusion_of(:has_defined_benefit_pension).in_array(%w(yes no))
+    end
+
+    context 'when `has_defined_benefit_pension` is yes' do
+      it 'requires an answer to `considering_transferring_to_dc_pot`' do
+        subject.has_defined_benefit_pension = 'yes'
+
+        expect(subject).to validate_inclusion_of(:considering_transferring_to_dc_pot).in_array(%w(yes no))
+      end
+    end
   end
 
   context 'when eligible for guidance' do

--- a/spec/support/chrome.rb
+++ b/spec/support/chrome.rb
@@ -1,0 +1,12 @@
+require 'webdrivers/chromedriver'
+require 'selenium/webdriver'
+
+Capybara.register_driver :chrome do |app|
+  options = Selenium::WebDriver::Chrome::Options.new(args: %w(headless no-sandbox))
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+end
+
+Capybara.default_max_wait_time = 10 if ENV['TRAVIS']
+Capybara.server = :puma, { Silent: true }
+Capybara.javascript_driver = :chrome

--- a/spec/support/poltergeist.rb
+++ b/spec/support/poltergeist.rb
@@ -1,8 +1,0 @@
-require 'capybara/poltergeist'
-
-# Force installation when necessary
-Phantomjs.path
-
-Capybara.javascript_driver = :poltergeist
-Capybara.default_max_wait_time = 10 if ENV['TRAVIS']
-Capybara.server = :puma, { Silent: true }


### PR DESCRIPTION
Guiders can specify that the customer stated a DB pension and whether they
indicated to transfer their pot. This is for analysis at a later stage.