### PR TITLE
Notify accounts when Braille requested

### DIFF
--- a/app/controllers/appointment_summaries_controller.rb
+++ b/app/controllers/appointment_summaries_controller.rb
@@ -89,6 +89,7 @@ class AppointmentSummariesController < ApplicationController
   def send_notifications(appointment_summary)
     CreateTapActivity.perform_later(appointment_summary, current_user) if appointment_summary.telephone_appointment?
     NotifyViaEmail.perform_later(appointment_summary) if appointment_summary.can_be_emailed?
+    BrailleNotification.perform_later(appointment_summary) if appointment_summary.braille_notification?
   end
 
   def telephone_appointment?

--- a/app/jobs/braille_notification.rb
+++ b/app/jobs/braille_notification.rb
@@ -1,0 +1,29 @@
+require 'notifications/client'
+
+class BrailleNotification < ApplicationJob
+  queue_as :default
+
+  TEMPLATE_ID = '50e47c0e-a2df-43ee-9d2d-d5580b76d958'.freeze
+  RECIPIENT   = 'feedback@pensionwise.gov.uk'.freeze
+
+  def perform(appointment_summary, config: Rails.configuration.x.notify)
+    payload = notification(appointment_summary)
+
+    Notifications::Client.new(config.secret_id).send_email(payload)
+  end
+
+  private
+
+  def notification(appointment_summary)
+    {
+      email_address: RECIPIENT,
+      template_id: TEMPLATE_ID,
+      personalisation: {
+        reference_number: appointment_summary.reference_number,
+        guider_name: appointment_summary.guider_name,
+        date_of_appointment: appointment_summary.date_of_appointment.to_s(:pw_date_long),
+        date_of_creation: appointment_summary.created_at.in_time_zone('London')
+      }
+    }.to_json
+  end
+end

--- a/app/models/appointment_summary.rb
+++ b/app/models/appointment_summary.rb
@@ -138,6 +138,14 @@ class AppointmentSummary < ApplicationRecord # rubocop:disable ClassLength
       supplementary_pension_transfers
   end
 
+  def braille_notification?
+    eligible_for_guidance? && braille? && !requested_digital?
+  end
+
+  def braille?
+    format_preference == 'braille'
+  end
+
   private
 
   def uk_address?

--- a/spec/controllers/appointment_summaries_controller_spec.rb
+++ b/spec/controllers/appointment_summaries_controller_spec.rb
@@ -24,6 +24,16 @@ RSpec.describe AppointmentSummariesController, 'GET #new', type: :controller do
       build(:appointment_summary, requested_digital: requested_digital, email: email).attributes
     end
 
+    context 'when the customer requests braille' do
+      it 'notifies the admins' do
+        summary = build_stubbed(:appointment_summary, format_preference: 'braille').attributes
+
+        expect(BrailleNotification).to receive(:perform_later).with(an_instance_of(AppointmentSummary))
+
+        post :create, params: { appointment_summary: summary }
+      end
+    end
+
     context 'when the customer has requested a digital summary document' do
       let(:requested_digital) { true }
 

--- a/spec/jobs/braille_notification_spec.rb
+++ b/spec/jobs/braille_notification_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe BrailleNotification do
+  let(:appointment_summary) { create(:appointment_summary) }
+  let(:config) { double(:config, service_id: 'service', secret_id: 'secret') }
+  let(:client) { double('Notifications::Client', send_email: true) }
+
+  before do
+    allow(Notifications::Client).to receive(:new).and_return(client)
+  end
+
+  it 'sends an email notification' do
+    expect(client).to receive(:send_email).with(
+      {
+        email_address: BrailleNotification::RECIPIENT,
+        template_id: BrailleNotification::TEMPLATE_ID,
+        personalisation: {
+          reference_number: appointment_summary.reference_number,
+          guider_name: appointment_summary.guider_name,
+          date_of_appointment: appointment_summary.date_of_appointment.to_s(:pw_date_long),
+          date_of_creation: appointment_summary.created_at.in_time_zone('London')
+        }
+      }.to_json
+    )
+
+    described_class.perform_now(appointment_summary, config: config)
+  end
+end

--- a/spec/models/appointment_summary_spec.rb
+++ b/spec/models/appointment_summary_spec.rb
@@ -144,4 +144,17 @@ RSpec.describe AppointmentSummary, type: :model do
 
     it { is_expected.to be_eligible_for_guidance }
   end
+
+  describe '#braille_notification?' do
+    it 'returns true when braille notification is needed' do
+      summary = build_stubbed(:appointment_summary)
+
+      expect(summary).not_to be_braille_notification
+
+      summary.requested_digital = false
+      summary.format_preference = 'braille'
+
+      expect(summary).to be_braille_notification
+    end
+  end
 end


### PR DESCRIPTION
Sends a notification email to the feedback inbox when a customer
requests a Braille document.