### PR TITLE
Alter eligibility rules

### DIFF
--- a/app/models/appointment_summary.rb
+++ b/app/models/appointment_summary.rb
@@ -112,7 +112,7 @@ class AppointmentSummary < ApplicationRecord # rubocop:disable ClassLength
 
   def eligible_for_guidance?
     %w(yes unknown).include?(has_defined_contribution_pension) ||
-      has_defined_benefit_pension == 'yes'
+      (has_defined_benefit_pension == 'yes' && considering_transferring_to_dc_pot == 'yes')
   end
 
   def can_be_emailed?

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -59,7 +59,7 @@ FactoryBot.define do
     trait :has_defined_benefit_pension do
       has_defined_contribution_pension 'no'
       has_defined_benefit_pension 'yes'
-      considering_transferring_to_dc_pot 'no'
+      considering_transferring_to_dc_pot 'yes'
     end
 
     factory :notify_delivered_appointment_summary do


### PR DESCRIPTION
The customer should be ineligible if they specified a DB pension but did
not state they would transfer the pension.