### PR TITLE
Include the `reference_number` column for export

### DIFF
--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -11,7 +11,8 @@ namespace :export do
              'appointment_summaries.created_at >= :ts  or appointment_summaries.updated_at >= :ts', ts: from_timestamp
            )
            .select(
-             "appointment_summaries.id, telephone_appointment, users.organisation_content_id as organisation_id,
+             "appointment_summaries.id, reference_number, telephone_appointment,
+              users.organisation_content_id as organisation_id,
               date_of_appointment, substring(postcode from '([A-z]{1,2})[0-9]') as postcode,
               country, appointment_type, has_defined_contribution_pension,
               requested_digital, appointment_summaries.created_at, appointment_summaries.updated_at"


### PR DESCRIPTION
This helps associate records across disparate systems.