### PR TITLE
Always require postcode component

### DIFF
--- a/app/models/appointment_summary.rb
+++ b/app/models/appointment_summary.rb
@@ -52,13 +52,13 @@ class AppointmentSummary < ApplicationRecord # rubocop:disable ClassLength
 
   validates :guider_name, presence: true, if: :pension_wise?
 
-  validates :address_line_1, presence: true, length: { maximum: 50 }, unless: :requested_digital?
-  validates :address_line_2, length: { maximum: 50 }, unless: :requested_digital?
-  validates :address_line_3, length: { maximum: 50 }, unless: :requested_digital?
-  validates :town, presence: true, length: { maximum: 50 }, unless: :requested_digital?
-  validates :county, length: { maximum: 50 }, unless: :requested_digital?
-  validates :postcode, presence: true, postcode: true, if: :uk_address?
-  validates :country, presence: true, inclusion: { in: Countries.all }, unless: :requested_digital?
+  validates :address_line_1, presence: true, length: { maximum: 50 }, if: :requested_postal?
+  validates :address_line_2, length: { maximum: 50 }, if: :requested_postal?
+  validates :address_line_3, length: { maximum: 50 }, if: :requested_postal?
+  validates :town, presence: true, length: { maximum: 50 }, if: :requested_postal?
+  validates :county, length: { maximum: 50 }, if: :requested_postal?
+  validates :postcode, presence: true, postcode: true, if: :postcode_required?
+  validates :country, presence: true, inclusion: { in: Countries.all }, if: :requested_postal?
 
   validates :has_defined_contribution_pension,
             presence: true,
@@ -101,6 +101,10 @@ class AppointmentSummary < ApplicationRecord # rubocop:disable ClassLength
 
   def self.editable_column_names
     column_names - %w(id created_at updated_at user_id notification_id)
+  end
+
+  def requested_postal?
+    !requested_digital?
   end
 
   def has_defined_contribution_pension # rubocop:disable PredicateName
@@ -178,7 +182,7 @@ class AppointmentSummary < ApplicationRecord # rubocop:disable ClassLength
 
   private
 
-  def uk_address?
-    Countries.uk?(country)
+  def postcode_required?
+    requested_digital? || Countries.uk?(country)
   end
 end

--- a/spec/models/appointment_summary_spec.rb
+++ b/spec/models/appointment_summary_spec.rb
@@ -142,7 +142,17 @@ RSpec.describe AppointmentSummary, type: :model do
     end
   end
 
-  describe 'postcode validation' do
+  context 'when digital delivery' do
+    describe 'postcode validation' do
+      before { subject.requested_digital = true }
+
+      it { is_expected.to validate_presence_of(:postcode) }
+    end
+  end
+
+  context 'for postal delivery' do
+    before { subject.requested_digital = false }
+
     context 'for UK addresses' do
       before { subject.country = Countries.uk }
 


### PR DESCRIPTION
When the customer chooses digital delivery, we only need to capture the
postcode for data analysis. Not the whole address. For postal
appointments we always capture the full address components.