### PR TITLE
Don't validate format of non-UK postcodes

### DIFF
--- a/app/models/appointment_summary.rb
+++ b/app/models/appointment_summary.rb
@@ -57,7 +57,8 @@ class AppointmentSummary < ApplicationRecord # rubocop:disable ClassLength
   validates :address_line_3, length: { maximum: 50 }, if: :requested_postal?
   validates :town, presence: true, length: { maximum: 50 }, if: :requested_postal?
   validates :county, length: { maximum: 50 }, if: :requested_postal?
-  validates :postcode, presence: true, postcode: true, if: :postcode_required?
+  validates :postcode, presence: true
+  validates :postcode, postcode: true, if: :postcode_format_required?
   validates :country, presence: true, inclusion: { in: Countries.all }, if: :requested_postal?
 
   validates :has_defined_contribution_pension,
@@ -182,7 +183,7 @@ class AppointmentSummary < ApplicationRecord # rubocop:disable ClassLength
 
   private
 
-  def postcode_required?
-    requested_digital? || Countries.uk?(country)
+  def postcode_format_required?
+    requested_postal? && Countries.uk?(country)
   end
 end

--- a/spec/models/appointment_summary_spec.rb
+++ b/spec/models/appointment_summary_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe AppointmentSummary, type: :model do
     context 'for non-UK addresses' do
       before { subject.country = Countries.non_uk.sample }
 
-      it { is_expected.to_not validate_presence_of(:postcode) }
+      it { is_expected.to validate_presence_of(:postcode) }
       it { is_expected.to allow_value('nonsense').for(:postcode) }
     end
   end


### PR DESCRIPTION
Because the country dropdown defaults to UK, when the change was made to
always validate postcodes, regardless of country of origin, the
validation is overzealous in that it should always validate the presence
of a given postcode, but only the format when it's UK.