### PR TITLE
Configure sidekiq's redis connection

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,7 @@
+Sidekiq.configure_server do |config|
+  config.redis = { ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE } }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE } }
+end


### PR DESCRIPTION
Heroku terminates the SSL connection to the redis instances using
self-signed certificates so we need to configure sidekiq's redis
connections to not verify.