### PR TITLE
Ensure TAP users have the phone permission

### DIFF
--- a/app/controllers/appointment_summaries_controller.rb
+++ b/app/controllers/appointment_summaries_controller.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AppointmentSummariesController < ApplicationController
+class AppointmentSummariesController < ApplicationController # rubocop:disable ClassLength
   before_action :authenticate_as_team_leader!, only: :index
   before_action :check_can_create_appointments!, only: [:new, :confirm, :create]
   before_action :load_summary, only: %i(new email_confirmation update confirm)
@@ -14,6 +14,8 @@ class AppointmentSummariesController < ApplicationController
   def new
     if instruct?
       render :summarise_via_tap
+    elsif tap_user_needs_phone_permission?
+      render :tap_user_needs_phone_permission
     else
       @appointment_summary.assign_attributes(appointment_summary_params)
     end
@@ -65,6 +67,12 @@ class AppointmentSummariesController < ApplicationController
   end
 
   private
+
+  def tap_user_needs_phone_permission?
+    params.dig(:appointment_summary, :telephone_appointment) == 'true' &&
+      !current_user.has_permission?(User::TELEPHONE_APPOINTMENT_PERMISSION) &&
+      !current_user.team_leader?
+  end
 
   def instruct?
     !current_user.has_permission?(User::FACE_TO_FACE_PERMISSION) && !params[:appointment_summary]

--- a/app/views/appointment_summaries/tap_user_needs_phone_permission.html.erb
+++ b/app/views/appointment_summaries/tap_user_needs_phone_permission.html.erb
@@ -1,0 +1,5 @@
+<div class="page-header">
+  <h1>You do not have the required permission</h1>
+</div>
+
+<p class="help-block t-no-permission">You need the telephone guider permission to summarise appointments via TAP.</p>

--- a/spec/features/tap_summary_document_generation_spec.rb
+++ b/spec/features/tap_summary_document_generation_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 RSpec.feature 'Appointment Summaries', js: true do
+  scenario 'Attempting to summarise a phone appointment without the correct permissions' do
+    given_i_am_logged_in_as_a_face_to_face_guider
+    when_the_guider_follows_the_tap_summary_link
+    then_they_are_told_they_do_not_have_the_correct_permissions
+  end
+
   scenario 'Regenerating an existing appointment summary' do
     given_i_am_logged_in_as_a_phone_guider
     and_an_existing_appointment_summary
@@ -11,6 +17,29 @@ RSpec.feature 'Appointment Summaries', js: true do
     then_the_confirmation_is_displayed
     when_the_guider_confirms_the_details
     then_the_existing_summary_is_updated
+  end
+
+  def given_i_am_logged_in_as_a_face_to_face_guider
+    create(:user, :face_to_face_guider)
+  end
+
+  def when_the_guider_follows_the_tap_summary_link
+    @page = AppointmentSummaryPage.new.tap do |page|
+      page.load(
+        date_of_appointment: '2017-02-02',
+        email: 'george@example.com',
+        first_name: 'George',
+        last_name: 'Georgeson',
+        guider_name: 'Jan Janson',
+        number_of_previous_appointments: '0',
+        reference_number: '123456',
+        telephone_appointment: 'true'
+      )
+    end
+  end
+
+  def then_they_are_told_they_do_not_have_the_correct_permissions
+    expect(@page).to have_tap_permission_warning
   end
 
   def given_i_am_logged_in_as_a_phone_guider

--- a/spec/support/pages/appointment_summary_page.rb
+++ b/spec/support/pages/appointment_summary_page.rb
@@ -7,6 +7,7 @@ class AppointmentSummaryPage < SitePrism::Page
   set_url '/appointment_summaries/new{?params*}'
   set_url_matcher %r{/appointment_summaries/new}
 
+  element :tap_permission_warning, '.t-no-permission'
   element :use_tap_warning, '.t-use-tap'
   element :due_diligence_banner, '.t-due-diligence-banner'
 


### PR DESCRIPTION
This will ensure TAP users cannot create incorrectly attributed
summaries if they do not have the correct permission. Prior to this
change these appointments were attributed to the face-to-face channel.