### PR TITLE
Notify all TAP appointments

### DIFF
--- a/app/controllers/api/v1/appointment_summaries_controller.rb
+++ b/app/controllers/api/v1/appointment_summaries_controller.rb
@@ -19,7 +19,8 @@ module Api
         @appointment_summary = AppointmentSummary.for_tap_reissue(params[:id])
 
         if @appointment_summary.update(email: params[:email])
-          @appointment_summary.notify_via_email(params[:initiator_uid])
+          @appointment_summary.notify_via_email
+          CreateTapActivity.perform_later(@appointment_summary, params[:initiator_uid])
 
           head :ok
         else

--- a/app/controllers/appointment_summaries_controller.rb
+++ b/app/controllers/appointment_summaries_controller.rb
@@ -95,8 +95,9 @@ class AppointmentSummariesController < ApplicationController
   end
 
   def send_notifications(appointment_summary)
-    appointment_summary.notify_via_email(current_user)
+    appointment_summary.notify_via_email
 
+    CreateTapActivity.perform_later(appointment_summary, current_user) if telephone_appointment?
     BrailleNotification.perform_later(appointment_summary) if appointment_summary.braille_notification?
   end
 

--- a/app/models/appointment_summary.rb
+++ b/app/models/appointment_summary.rb
@@ -189,7 +189,7 @@ class AppointmentSummary < ApplicationRecord # rubocop:disable ClassLength
     schedule_type == 'due_diligence'
   end
 
-  def notify_via_email(current_user = nil)
+  def notify_via_email
     return unless can_be_emailed?
 
     if due_diligence?
@@ -197,8 +197,6 @@ class AppointmentSummary < ApplicationRecord # rubocop:disable ClassLength
     else
       NotifyViaEmail.perform_later(self)
     end
-
-    CreateTapActivity.perform_later(self, current_user) if telephone_appointment?
   end
 
   private

--- a/spec/controllers/appointment_summaries_controller_spec.rb
+++ b/spec/controllers/appointment_summaries_controller_spec.rb
@@ -45,6 +45,19 @@ RSpec.describe AppointmentSummariesController, 'GET #new', type: :controller do
 
           post :create, params: { appointment_summary: appointment_summary }
         end
+
+        context 'when they are a phone user' do
+          let(:user) { create(:user, :phone_guider, email: email) }
+
+          it 'also notifies tap' do
+            expect(CreateTapActivity).to receive(:perform_later).with(
+              an_instance_of(AppointmentSummary),
+              user
+            )
+
+            post :create, params: { appointment_summary: appointment_summary }
+          end
+        end
       end
 
       context 'and has not provided a valid email address' do


### PR DESCRIPTION
TAP ought to be notified for any phone appointment, regardless whether
it's a digital or postal summary.