### PR TITLE
Allow uppercase email addresses

### DIFF
--- a/app/models/appointment_summary.rb
+++ b/app/models/appointment_summary.rb
@@ -4,7 +4,7 @@ class AppointmentSummary < ApplicationRecord # rubocop:disable ClassLength
   DIGITAL_BY_DEFAULT_START_DATE = Date.new(2016, 6, 21)
   # bassed off: https://github.com/alphagov/notifications-utils/blob/master/notifications_utils/recipients.py#L22
   EMAIL_REGEXP = Regexp.union(
-    /\A([^";@\s\.]+\.)*[^";@\s\.]+@([^";@\s\.]+\.)+[a-z]{2,10}\z/,
+    /\A([^";@\s\.]+\.)*[^";@\s\.]+@([^";@\s\.]+\.)+[a-zA-Z]{2,10}\z/,
     /\A\z/
   )
 

--- a/spec/models/appointment_summary_spec.rb
+++ b/spec/models/appointment_summary_spec.rb
@@ -110,6 +110,7 @@ RSpec.describe AppointmentSummary, type: :model do
 
   shared_examples 'it is a valid email' do
     it { is_expected.to allow_value('fred.jones@pensionwise.gov.uk').for(:email) }
+    it { is_expected.to allow_value('FRED@PENSIONWISE.GOV.UK').for(:email) }
     it { is_expected.not_to allow_value('fred.jones').for(:email) }
     it { is_expected.not_to allow_value('fred@no-extension').for(:email) }
     it { is_expected.not_to allow_value('  fred@spaced.com  ').for(:email) }


### PR DESCRIPTION
This can cause issues with the TAP integration since they're not normalised on each side. Requiring lowercase emails can mean that agents must re-enter the email in lowercase in TAP when it's provided by a customer in uppercase.