### PR TITLE
Allow the first/last name and email edits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ before_script:
 - '(cd .downloads; [ -d prince-9.0r5-linux-amd64-static ] || curl -s https://www.princexml.com/download/prince-9.0r5-linux-amd64-static.tar.gz | tar xzf -)'
 - echo $PWD | ./.downloads/prince-9.0r5-linux-amd64-static/install.sh
 - npm install
-- npx @puppeteer/browsers install chromedriver@119.0.6045.105 --path $PWD/bin
-- export PATH=$PWD/bin/chromedriver/linux-119.0.6045.105/chromedriver-linux64:$PATH
+- npx @puppeteer/browsers install chromedriver@121.0.6167.85 --path $PWD/bin
+- export PATH=$PWD/bin/chromedriver/linux-121.0.6167.85/chromedriver-linux64:$PATH
 - './bin/rake db:setup RAILS_ENV=test'
 notifications:
   slack:

--- a/app/views/appointment_summaries/new.html.erb
+++ b/app/views/appointment_summaries/new.html.erb
@@ -23,18 +23,18 @@
 
       <div class="form-group">
         <%= f.label :first_name %>
-        <%= f.text_field :first_name, class: %w(form-control input-md-3 t-first-name), readonly: @appointment_summary.telephone_appointment? %>
+        <%= f.text_field :first_name, class: %w(form-control input-md-3 t-first-name) %>
       </div>
 
       <div class="form-group">
         <%= f.label :last_name %>
-        <%= f.text_field :last_name, class: %w(form-control input-md-3 t-last-name), readonly: @appointment_summary.telephone_appointment? %>
+        <%= f.text_field :last_name, class: %w(form-control input-md-3 t-last-name) %>
       </div>
 
       <div class="form-group">
         <%= f.label :email %>
         <div class="email-outer input-md-3">
-          <%= f.email_field :email, class: %w(form-control js-email-validation t-email), readonly: @appointment_summary.telephone_appointment? %>
+          <%= f.email_field :email, class: %w(form-control js-email-validation t-email) %>
         </div>
       </div>
 


### PR DESCRIPTION
These fields were previously marked as readonly and now need to be editable for TAP reissuing.