### PR TITLE
Turn autocomplete off

### DIFF
--- a/app/views/appointment_summaries/new.html.erb
+++ b/app/views/appointment_summaries/new.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @appointment_summary, url: confirm_appointment_summaries_path, method: :post do |f| %>
+<%= form_for @appointment_summary, url: confirm_appointment_summaries_path, method: :post, html: { autocomplete: 'off' } do |f| %>
   <%= f.hidden_field :telephone_appointment %>
   <%= f.hidden_field :schedule_type %>
   <%= f.hidden_field :unique_reference_number %>


### PR DESCRIPTION
This might help with agents using incorrect details when completing summary documents.