### PR TITLE
Include 'covering letter' type content in email

### DIFF
--- a/app/jobs/notify_via_email.rb
+++ b/app/jobs/notify_via_email.rb
@@ -33,9 +33,17 @@ class NotifyViaEmail < ApplicationJob
         title: appointment_summary.title,
         last_name: appointment_summary.last_name,
         guider_name: appointment_summary.guider_name,
-        date_of_appointment: appointment_summary.date_of_appointment.to_s(:pw_date_long)
+        date_of_appointment: appointment_summary.date_of_appointment.to_s(:pw_date_long),
+        section_32: covering_letter_content(appointment_summary, 'section_32'), # rubocop:disable Naming/VariableNumber
+        adjustable_income: covering_letter_content(appointment_summary, 'adjustable_income'),
+        inherited_pot: covering_letter_content(appointment_summary, 'inherited_pot'),
+        fixed_term_annuity: covering_letter_content(appointment_summary, 'fixed_term_annuity')
       }
     }.to_json
+  end
+
+  def covering_letter_content(appointment_summary, type)
+    appointment_summary.covering_letter_type == type ? 'yes' : 'no'
   end
 
   def template_id(appointment_summary, config)

--- a/spec/jobs/notify_via_email_spec.rb
+++ b/spec/jobs/notify_via_email_spec.rb
@@ -29,7 +29,11 @@ RSpec.describe NotifyViaEmail do
             title: appointment_summary.title,
             last_name: appointment_summary.last_name,
             guider_name: appointment_summary.guider_name,
-            date_of_appointment: appointment_summary.date_of_appointment.to_s(:pw_date_long)
+            date_of_appointment: appointment_summary.date_of_appointment.to_s(:pw_date_long),
+            section_32: 'yes', # rubocop:disable Naming/VariableNumber
+            adjustable_income: 'no',
+            inherited_pot: 'no',
+            fixed_term_annuity: 'no'
           }
         }.to_json
       )
@@ -40,7 +44,7 @@ RSpec.describe NotifyViaEmail do
 
   context 'when the customer does not have a DC pension' do
     let(:appointment_summary) do
-      create(:appointment_summary, :has_defined_benefit_pension)
+      create(:appointment_summary, :has_defined_benefit_pension, covering_letter_type: 'adjustable_income')
     end
 
     it 'sends an eligible email notification' do
@@ -53,7 +57,11 @@ RSpec.describe NotifyViaEmail do
             title: appointment_summary.title,
             last_name: appointment_summary.last_name,
             guider_name: appointment_summary.guider_name,
-            date_of_appointment: appointment_summary.date_of_appointment.to_s(:pw_date_long)
+            date_of_appointment: appointment_summary.date_of_appointment.to_s(:pw_date_long),
+            section_32: 'no', # rubocop:disable Naming/VariableNumber
+            adjustable_income: 'yes',
+            inherited_pot: 'no',
+            fixed_term_annuity: 'no'
           }
         }.to_json
       )


### PR DESCRIPTION
This appears in the printed or download versions but was always omitted from the email version. This change adds the 'covering letter' paragraph to the email content also.