### PR TITLE
Welsh Summary Documents

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ source 'https://rubygems.org' do # rubocop:disable Metrics/BlockLength
   gem 'notifications-ruby-client'
   gem 'observer'
   gem 'ostruct'
-  gem 'output-templates', github: 'guidance-guarantee-programme/output-templates', ref: 'aa49996'
+  gem 'output-templates', github: 'guidance-guarantee-programme/output-templates', branch: 'welsh-language'
   gem 'pg'
   gem 'plek'
   gem 'postgres-copy'

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ source 'https://rubygems.org' do # rubocop:disable Metrics/BlockLength
   gem 'notifications-ruby-client'
   gem 'observer'
   gem 'ostruct'
-  gem 'output-templates', github: 'guidance-guarantee-programme/output-templates', branch: 'welsh-language'
+  gem 'output-templates', github: 'guidance-guarantee-programme/output-templates', ref: '2e1bed5'
   gem 'pg'
   gem 'plek'
   gem 'postgres-copy'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/guidance-guarantee-programme/output-templates.git
-  revision: 60b68e19a64dcf7b834f05e0fc8a9cf841069b36
-  branch: welsh-language
+  revision: 2e1bed589ead268228d0704e075e003b629adcf2
+  ref: 2e1bed5
   specs:
-    output-templates (7.0.0)
+    output-templates (7.2.0)
       actionview
       sassc
 
@@ -108,8 +108,8 @@ GEM
       net-http-persistent (~> 4.0)
       nokogiri (~> 1, >= 1.10.8)
     base64 (0.1.2)
-    benchmark (0.4.0)
-    bigdecimal (3.1.9)
+    benchmark (0.4.1)
+    bigdecimal (3.2.2)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     bootstrap-kaminari-views (0.0.5)
@@ -141,7 +141,7 @@ GEM
     database_rewinder (1.1.0)
     date (3.4.1)
     diff-lcs (1.5.0)
-    drb (2.2.1)
+    drb (2.2.3)
     erubi (1.13.1)
     execjs (2.9.1)
     factory_bot (4.10.0)
@@ -224,7 +224,7 @@ GEM
     launchy (2.4.3)
       addressable (~> 2.3)
     logger (1.7.0)
-    loofah (2.24.0)
+    loofah (2.24.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.8.1)
@@ -238,7 +238,7 @@ GEM
       actionpack (>= 6.0.0, < 8.1)
     method_source (1.1.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.8)
+    mini_portile2 (2.8.9)
     minitest (5.25.5)
     msgpack (1.7.2)
     multi_json (1.15.0)
@@ -338,7 +338,7 @@ GEM
       activesupport (= 8.0.2)
       bundler (>= 1.15.0)
       railties (= 8.0.2)
-    rails-dom-testing (2.2.0)
+    rails-dom-testing (2.3.0)
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/guidance-guarantee-programme/output-templates.git
-  revision: aa4999603c061ca4cf3d3460aa227602acc6f81e
-  ref: aa49996
+  revision: 60b68e19a64dcf7b834f05e0fc8a9cf841069b36
+  branch: welsh-language
   specs:
     output-templates (7.0.0)
       actionview

--- a/app/domain/output_document.rb
+++ b/app/domain/output_document.rb
@@ -10,6 +10,7 @@ class OutputDocument
            :supplementary_pension_transfers,
            :format_preference, :appointment_type,
            :unique_reference_number, :schedule_type, :reference_number,
+           :welsh?,
            to: :appointment_summary
 
   delegate :address_line_1, :address_line_2, :address_line_3, :town, :county, :postcode,

--- a/app/domain/output_document.rb
+++ b/app/domain/output_document.rb
@@ -69,7 +69,17 @@ class OutputDocument
   end
 
   def lead
-    "You recently had a Pension Wise guidance appointment with #{guider_first_name} on #{appointment_date}."
+    if appointment_summary.welsh?
+      @appointment_date = I18n.l(
+        appointment_summary.date_of_appointment,
+        locale: :cy,
+        format: Date::DATE_FORMATS[:gov_uk]
+      )
+
+      "Yn ddiweddar, cawsoch apwyntiad arweiniad Pension Wise gyda #{guider_first_name} ar #{@appointment_date}."
+    else
+      "You recently had a Pension Wise guidance appointment with #{guider_first_name} on #{appointment_date}."
+    end
   end
 
   def appointment_reference

--- a/app/jobs/notify_via_email.rb
+++ b/app/jobs/notify_via_email.rb
@@ -29,7 +29,7 @@ class NotifyViaEmail < ApplicationJob
       email_address: appointment_summary.email,
       template_id: template_id,
       personalisation: {
-        pdf_download_url: pdf_download_url(appointment_summary, config),
+        pdf_download_url: PdfDownloadUrlPresenter.new(appointment_summary, config).call,
         reference_number: appointment_summary.reference_number,
         title: appointment_summary.title,
         last_name: appointment_summary.last_name,
@@ -41,22 +41,6 @@ class NotifyViaEmail < ApplicationJob
         fixed_term_annuity: covering_letter_content(appointment_summary, 'fixed_term_annuity')
       }.merge(SummaryDocumentNextStepsPresenter.new(appointment_summary).to_h)
     }
-  end
-
-  def pdf_download_url(appointment_summary, config)
-    return '' unless appointment_summary.eligible_for_guidance?
-
-    if appointment_summary.standard?
-      if appointment_summary.supplementary_defined_benefit_pensions
-        config.standard_db_pdf_download_url
-      else
-        config.standard_pdf_download_url
-      end
-    elsif appointment_summary.supplementary_defined_benefit_pensions
-      config.non_standard_db_pdf_download_url
-    else
-      config.non_standard_pdf_download_url
-    end
   end
 
   def covering_letter_content(appointment_summary, type)

--- a/app/services/pdf_download_url_presenter.rb
+++ b/app/services/pdf_download_url_presenter.rb
@@ -1,0 +1,21 @@
+class PdfDownloadUrlPresenter
+  def initialize(appointment_summary, config)
+    @appointment_summary = appointment_summary
+    @config = config
+  end
+
+  def call
+    return '' unless appointment_summary.eligible_for_guidance?
+
+    standard = appointment_summary.standard? ? 'standard' : 'non-standard'
+    db       = appointment_summary.supplementary_defined_benefit_pensions ? '-db' : ''
+    locale   = appointment_summary.welsh? ? '-cy' : ''
+    filename = "#{standard}#{db}#{locale}.pdf"
+
+    [config.pdf_download_host, filename].join('/')
+  end
+
+  private
+
+  attr_reader :appointment_summary, :config
+end

--- a/app/views/appointment_summaries/new.html.erb
+++ b/app/views/appointment_summaries/new.html.erb
@@ -483,6 +483,29 @@
           </div>
         </fieldset>
       </div>
+
+      <div class="form-group">
+        <fieldset>
+          <legend>
+            <span>Document language</span>
+          </legend>
+
+          <div class="radio">
+            <label>
+              <%= f.radio_button :welsh, false,
+                                 class: 't-requested-english' %>
+              English
+            </label>
+          </div>
+          <div class="radio">
+            <label>
+              <%= f.radio_button :welsh, true,
+                                 class: 't-requested-welsh' %>
+              Welsh
+            </label>
+          </div>
+        </fieldset>
+      </div>
       <p>
         <%= f.submit 'Continue', class: %w(btn btn-primary t-submit) %>
       </p>

--- a/app/views/appointment_summaries/new.html.erb
+++ b/app/views/appointment_summaries/new.html.erb
@@ -484,7 +484,8 @@
         </fieldset>
       </div>
 
-      <div class="form-group">
+      <% if @appointment_summary.pension_wise? %>
+      <div class="form-group t-document-language">
         <fieldset>
           <legend>
             <span>Document language</span>
@@ -506,6 +507,7 @@
           </div>
         </fieldset>
       </div>
+      <% end %>
       <p>
         <%= f.submit 'Continue', class: %w(btn btn-primary t-submit) %>
       </p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,8 @@ Bundler.require(*Rails.groups)
 
 module Output
   class Application < Rails::Application
+    config.i18n.enforce_available_locales = false
+    config.i18n.available_locales = %i[en cy]
     config.action_mailer.default_url_options = { host: ENV['APPLICATION_HOST'] }
     config.active_job.queue_adapter = :sidekiq
 

--- a/config/initializers/notify.rb
+++ b/config/initializers/notify.rb
@@ -2,7 +2,9 @@
 Rails.configuration.x.notify.tap do |notify|
   notify.secret_id = ENV['NOTIFY_SECRET_ID']
   notify.appointment_summary_template_id = ENV['APPOINTMENT_SUMMARY_TEMPLATE_ID']
+  notify.welsh_appointment_summary_template_id = ENV['WELSH_APPOINTMENT_SUMMARY_TEMPLATE_ID']
   notify.ineligible_template_id = ENV['INELIGIBLE_TEMPLATE_ID']
+  notify.welsh_ineligible_template_id = ENV['WELSH_INELIGIBLE_TEMPLATE_ID']
 
   notify.due_diligence_secret_id = ENV['DUE_DILIGENCE_SECRET_ID']
   notify.due_diligence_summary_template_id = ENV['DUE_DILIGENCE_SUMMARY_TEMPLATE_ID']

--- a/config/initializers/notify.rb
+++ b/config/initializers/notify.rb
@@ -9,8 +9,5 @@ Rails.configuration.x.notify.tap do |notify|
   notify.due_diligence_secret_id = ENV['DUE_DILIGENCE_SECRET_ID']
   notify.due_diligence_summary_template_id = ENV['DUE_DILIGENCE_SUMMARY_TEMPLATE_ID']
 
-  notify.standard_pdf_download_url = ENV['STANDARD_PDF_DOWNLOAD_URL']
-  notify.non_standard_pdf_download_url = ENV['NON_STANDARD_PDF_DOWNLOAD_URL']
-  notify.standard_db_pdf_download_url = ENV['STANDARD_DB_PDF_DOWNLOAD_URL']
-  notify.non_standard_db_pdf_download_url = ENV['NON_STANDARD_DB_PDF_DOWNLOAD_URL']
+  notify.pdf_download_host = ENV['PDF_DOWNLOAD_HOST']
 end

--- a/db/migrate/20250519132353_add_welsh_to_appointment_summaries.rb
+++ b/db/migrate/20250519132353_add_welsh_to_appointment_summaries.rb
@@ -1,0 +1,5 @@
+class AddWelshToAppointmentSummaries < ActiveRecord::Migration[8.0]
+  def change
+    add_column :appointment_summaries, :welsh, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[6.1].define(version: 2025_03_18_201234) do
-
+ActiveRecord::Schema[8.0].define(version: 2025_05_19_132353) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
-  enable_extension "plpgsql"
 
   create_table "appointment_summaries", id: :serial, force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.date "date_of_appointment"
     t.money "value_of_pension_pots", scale: 2
     t.string "guider_name"
@@ -49,7 +48,7 @@ ActiveRecord::Schema[6.1].define(version: 2025_03_18_201234) do
     t.string "email", default: ""
     t.string "notification_id", default: ""
     t.boolean "supplementary_pension_transfers", default: false
-    t.datetime "notify_completed_at"
+    t.datetime "notify_completed_at", precision: nil
     t.integer "notify_status", default: 0, null: false
     t.boolean "telephone_appointment", default: true
     t.string "covering_letter_type", default: "", null: false
@@ -68,6 +67,7 @@ ActiveRecord::Schema[6.1].define(version: 2025_03_18_201234) do
     t.string "living_or_planning_overseas", default: "", null: false
     t.string "finalised_a_will", default: "", null: false
     t.string "setup_power_of_attorney", default: "", null: false
+    t.boolean "welsh", default: false, null: false
     t.index ["user_id"], name: "index_appointment_summaries_on_user_id"
   end
 
@@ -79,33 +79,33 @@ ActiveRecord::Schema[6.1].define(version: 2025_03_18_201234) do
   end
 
   create_table "batches", id: :serial, force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.datetime "uploaded_at"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "uploaded_at", precision: nil
   end
 
   create_table "users", id: :serial, force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: ""
     t.integer "sign_in_count", default: 0, null: false
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
+    t.datetime "current_sign_in_at", precision: nil
+    t.datetime "last_sign_in_at", precision: nil
     t.inet "current_sign_in_ip"
     t.inet "last_sign_in_ip"
     t.string "confirmation_token"
-    t.datetime "confirmed_at"
-    t.datetime "confirmation_sent_at"
+    t.datetime "confirmed_at", precision: nil
+    t.datetime "confirmation_sent_at", precision: nil
     t.string "unconfirmed_email"
     t.integer "failed_attempts", default: 0, null: false
     t.string "unlock_token"
-    t.datetime "locked_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "locked_at", precision: nil
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.string "organisation"
     t.string "invitation_token"
-    t.datetime "invitation_created_at"
-    t.datetime "invitation_sent_at"
-    t.datetime "invitation_accepted_at"
+    t.datetime "invitation_created_at", precision: nil
+    t.datetime "invitation_sent_at", precision: nil
+    t.datetime "invitation_accepted_at", precision: nil
     t.integer "invitation_limit"
     t.integer "invited_by_id"
     t.string "invited_by_type"
@@ -113,7 +113,7 @@ ActiveRecord::Schema[6.1].define(version: 2025_03_18_201234) do
     t.string "first_name"
     t.string "last_name"
     t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
+    t.datetime "reset_password_sent_at", precision: nil
     t.string "role", default: "", null: false
     t.string "name", default: ""
     t.string "uid", default: "", null: false

--- a/lib/tasks/summary_variant_pdfs.rake
+++ b/lib/tasks/summary_variant_pdfs.rake
@@ -1,0 +1,94 @@
+class OutputDocument
+  attr_reader :filename, :supplementary_defined_benefit_pensions
+
+  def initialize(filename:, type:, welsh:, supplementary_defined_benefit_pensions:)
+    @filename = filename
+    @type = type
+    @welsh = welsh
+    @supplementary_defined_benefit_pensions = supplementary_defined_benefit_pensions
+  end
+
+  def welsh?
+    @welsh
+  end
+
+  def appointment_type
+    @type
+  end
+
+  def envelope_class
+    'l-envelope--tpas'
+  end
+
+  def format_preference
+    'standard'
+  end
+
+  def next_steps?
+    false
+  end
+
+  def supplementary_benefits
+    true
+  end
+
+  def supplementary_debt
+    true
+  end
+
+  def supplementary_ill_health
+    true
+  end
+
+  def supplementary_pension_transfers
+    true
+  end
+
+  def covering_letter_type
+    ''
+  end
+
+  def variant
+    'generic'
+  end
+
+  def generate_pdf
+    html = Output::Templates.template('generic').render(self)
+    Princely::Pdf.new.pdf_from_string_to_file(html, "/tmp/#{filename}")
+
+    puts "Written PDF: #{filename}"
+  end
+end
+
+# rubocop:disable Metrics/BlockLength
+namespace :summary_variants do
+  task pdfs: :environment do
+    [
+      OutputDocument.new(
+        filename: 'standard.pdf', type: 'standard', welsh: false, supplementary_defined_benefit_pensions: false
+      ),
+      OutputDocument.new(
+        filename: 'standard-cy.pdf', type: 'standard', welsh: true, supplementary_defined_benefit_pensions: false
+      ),
+      OutputDocument.new(
+        filename: 'standard-db.pdf', type: 'standard', welsh: false, supplementary_defined_benefit_pensions: true
+      ),
+      OutputDocument.new(
+        filename: 'standard-db-cy.pdf', type: 'standard', welsh: true, supplementary_defined_benefit_pensions: true
+      ),
+      OutputDocument.new(
+        filename: 'non-standard.pdf', type: '50_54', welsh: false, supplementary_defined_benefit_pensions: false
+      ),
+      OutputDocument.new(
+        filename: 'non-standard-cy.pdf', type: '50_54', welsh: true, supplementary_defined_benefit_pensions: false
+      ),
+      OutputDocument.new(
+        filename: 'non-standard-db.pdf', type: '50_54', welsh: false, supplementary_defined_benefit_pensions: true
+      ),
+      OutputDocument.new(
+        filename: 'non-standard-db-cy.pdf', type: '50_54', welsh: true, supplementary_defined_benefit_pensions: true
+      )
+    ].each(&:generate_pdf)
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/spec/domain/output_document_spec.rb
+++ b/spec/domain/output_document_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe OutputDocument do
       value_of_pension_pots: value_of_pension_pots,
       upper_value_of_pension_pots: upper_value_of_pension_pots,
       value_of_pension_pots_is_approximate: value_of_pension_pots_is_approximate,
-      guider_name: guider_name
+      guider_name: guider_name,
+      welsh: false
     }
   end
   let(:appointment_summary) { AppointmentSummary.new(params) }
@@ -44,6 +45,7 @@ RSpec.describe OutputDocument do
   subject(:output_document) { described_class.new(appointment_summary) }
 
   specify { expect(output_document.attendee_name).to eq(attendee_name) }
+  specify { expect(output_document.welsh?).to eq(false) }
   specify { expect(output_document.appointment_date).to eq(appointment_date) }
 
   describe '#attendee_country' do

--- a/spec/domain/output_document_spec.rb
+++ b/spec/domain/output_document_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe OutputDocument do
   let(:date_of_appointment) { Date.new(2015, 3, 9) }
   let(:appointment_date) { '9 March 2015' }
   let(:reference_number) { '123456789' }
+  let(:welsh) { false }
   let(:params) do
     {
       title: title,
@@ -37,7 +38,7 @@ RSpec.describe OutputDocument do
       upper_value_of_pension_pots: upper_value_of_pension_pots,
       value_of_pension_pots_is_approximate: value_of_pension_pots_is_approximate,
       guider_name: guider_name,
-      welsh: false
+      welsh: welsh
     }
   end
   let(:appointment_summary) { AppointmentSummary.new(params) }
@@ -146,10 +147,22 @@ RSpec.describe OutputDocument do
   describe '#lead' do
     subject { output_document.lead }
 
-    it do
-      is_expected.to eq(
-        "You recently had a Pension Wise guidance appointment with James on #{appointment_date}."
-      )
+    context 'when English' do
+      it do
+        is_expected.to eq(
+          "You recently had a Pension Wise guidance appointment with James on #{appointment_date}."
+        )
+      end
+    end
+
+    context 'when Welsh' do
+      let(:welsh) { true }
+
+      it do
+        is_expected.to eq(
+          'Yn ddiweddar, cawsoch apwyntiad arweiniad Pension Wise gyda James ar 9 Mawrth 2015.'
+        )
+      end
     end
   end
 

--- a/spec/features/tap_due_diligence_summary_document_generation_spec.rb
+++ b/spec/features/tap_due_diligence_summary_document_generation_spec.rb
@@ -55,6 +55,7 @@ RSpec.feature 'Due diligence appointment summary', js: true do
     expect(@page).to have_no_first_appointment_yes
     expect(@page).to have_no_has_defined_contribution_pension_yes
     expect(@page).to have_no_guider_name
+    expect(@page).to have_no_document_language
   end
 
   def when_they_complete_the_summary_document

--- a/spec/features/tap_summary_document_generation_spec.rb
+++ b/spec/features/tap_summary_document_generation_spec.rb
@@ -33,7 +33,8 @@ RSpec.feature 'Appointment Summaries', js: true do
         guider_name: 'Jan Janson',
         number_of_previous_appointments: '0',
         reference_number: '123456',
-        telephone_appointment: 'true'
+        telephone_appointment: 'true',
+        welsh: 'false'
       )
     end
   end
@@ -60,7 +61,8 @@ RSpec.feature 'Appointment Summaries', js: true do
         last_name: 'Georgeson',
         guider_name: 'Jan Janson',
         number_of_previous_appointments: '0',
-        reference_number: '123456'
+        reference_number: '123456',
+        welsh: 'false'
       )
     end
   end
@@ -79,15 +81,11 @@ RSpec.feature 'Appointment Summaries', js: true do
     expect(@page.first_name.value).to eq('George')
     expect(@page.last_name.value).to eq('Georgeson')
     expect(@page.guider_name.value).to eq('Jan Janson')
+    expect(@page.welsh.selected_value).to eq('false')
   end
 
   def when_the_guider_modifies_the_summary
-    # https://stackoverflow.com/a/45332510
-    while @page.address_line_1.value != '5 Grange Hill'
-      @page.address_line_1.set('5 Grange Hill')
-      sleep 0.25
-    end
-
+    @page.address_line_1.set('5 Grange Hill')
     @page.submit.click
   end
 

--- a/spec/jobs/notify_via_email_spec.rb
+++ b/spec/jobs/notify_via_email_spec.rb
@@ -11,10 +11,7 @@ RSpec.describe NotifyViaEmail do
       welsh_appointment_summary_template_id: 'welsh_template',
       ineligible_template_id: 'ineligible_template',
       welsh_ineligible_template_id: 'welsh_ineligible_template',
-      standard_pdf_download_url: 'https://example.com/standard.pdf',
-      non_standard_pdf_download_url: 'https://example.com/non-standard.pdf',
-      standard_db_pdf_download_url: 'https://example.com/standard-db.pdf',
-      non_standard_db_pdf_download_url: 'https://example.com/non-standard-db.pdf'
+      pdf_download_host: 'https://example.com'
     )
   end
   let(:personalisation) do

--- a/spec/jobs/notify_via_email_spec.rb
+++ b/spec/jobs/notify_via_email_spec.rb
@@ -8,18 +8,87 @@ RSpec.describe NotifyViaEmail do
       service_id: 'service',
       secret_id: 'secret',
       appointment_summary_template_id: 'template',
+      welsh_appointment_summary_template_id: 'welsh_template',
       ineligible_template_id: 'ineligible_template',
+      welsh_ineligible_template_id: 'welsh_ineligible_template',
       standard_pdf_download_url: 'https://example.com/standard.pdf',
       non_standard_pdf_download_url: 'https://example.com/non-standard.pdf',
       standard_db_pdf_download_url: 'https://example.com/standard-db.pdf',
       non_standard_db_pdf_download_url: 'https://example.com/non-standard-db.pdf'
     )
   end
+  let(:personalisation) do
+    {
+      pdf_download_url: 'https://example.com/standard.pdf',
+      reference_number: appointment_summary.reference_number,
+      title: appointment_summary.title,
+      last_name: appointment_summary.last_name,
+      guider_name: appointment_summary.guider_name,
+      date_of_appointment: appointment_summary.date_of_appointment.to_fs(:pw_date_long),
+      section_32: 'yes', # rubocop:disable Naming/VariableNumber
+      adjustable_income: 'no',
+      inherited_pot: 'no',
+      fixed_term_annuity: 'no',
+      updated_beneficiaries: 'no',
+      regulated_financial_advice: 'yes',
+      kept_track_of_all_pensions: 'no',
+      interested_in_pension_transfer: 'yes',
+      created_retirement_budget: 'no',
+      know_how_much_state_pension: 'no',
+      received_state_benefits: 'yes',
+      pension_to_pay_off_debts: 'yes',
+      living_or_planning_overseas: 'yes',
+      finalised_a_will: 'no',
+      setup_power_of_attorney: 'no'
+    }
+  end
   let(:client) { double('Notifications::Client', send_email: response) }
   let(:response) { double('Notifications::Client', id: '12345') }
 
   before do
     allow(Notifications::Client).to receive(:new).and_return(client)
+  end
+
+  describe 'Notify template selection' do
+    context 'when eligible and Welsh' do
+      it 'selects the correct template ID' do
+        appointment_summary.welsh = true
+
+        expect(client).to receive(:send_email).with(hash_including(
+                                                      email_address: appointment_summary.email,
+                                                      template_id: 'welsh_template'
+                                                    ))
+
+        described_class.perform_now(appointment_summary, config: config)
+      end
+    end
+
+    context 'when ineligible and Welsh' do
+      it 'selects the correct template ID' do
+        appointment_summary.welsh = true
+        appointment_summary.has_defined_contribution_pension = 'no'
+
+        expect(client).to receive(:send_email).with(hash_including(
+                                                      email_address: appointment_summary.email,
+                                                      template_id: 'welsh_ineligible_template'
+                                                    ))
+
+        described_class.perform_now(appointment_summary, config: config)
+      end
+    end
+
+    context 'when ineligible' do
+      it 'selects the correct template ID' do
+        appointment_summary.has_defined_contribution_pension = 'no'
+
+        expect(client).to receive(:send_email).with(hash_including(
+                                                      email_address: appointment_summary.email,
+                                                      template_id: 'ineligible_template'
+                                                    ))
+
+        described_class.perform_now(appointment_summary, config: config)
+      end
+    end
   end
 
   context 'when the customer has a DC pension' do
@@ -51,7 +120,7 @@ RSpec.describe NotifyViaEmail do
             finalised_a_will: 'no',
             setup_power_of_attorney: 'no'
           }
-        }.to_json
+        }
       )
 
       described_class.perform_now(appointment_summary, config: config)
@@ -96,7 +165,7 @@ RSpec.describe NotifyViaEmail do
             finalised_a_will: 'no',
             setup_power_of_attorney: 'no'
           }
-        }.to_json
+        }
       )
 
       described_class.perform_now(appointment_summary, config: config)

--- a/spec/services/pdf_download_url_presenter_spec.rb
+++ b/spec/services/pdf_download_url_presenter_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe PdfDownloadUrlPresenter, '#call' do
+  let(:config) { double(pdf_download_host: 'https://example.com') }
+
+  context 'when appointment is standard, English' do
+    it 'specifies the correct file URL' do
+      appointment = double(
+        eligible_for_guidance?: true,
+        standard?: true,
+        supplementary_defined_benefit_pensions: false,
+        welsh?: false
+      )
+
+      expect(described_class.new(appointment, config).call).to eq('https://example.com/standard.pdf')
+    end
+  end
+
+  context 'when appointment is non-standard, DB, English' do
+    it 'specifies the correct file URL' do
+      appointment = double(
+        eligible_for_guidance?: true,
+        standard?: false,
+        supplementary_defined_benefit_pensions: true,
+        welsh?: false
+      )
+
+      expect(described_class.new(appointment, config).call).to eq('https://example.com/non-standard-db.pdf')
+    end
+  end
+
+  context 'when appointment is non-standard, DB, Welsh' do
+    it 'specifies the correct file URL' do
+      appointment = double(
+        eligible_for_guidance?: true,
+        standard?: false,
+        supplementary_defined_benefit_pensions: true,
+        welsh?: true
+      )
+
+      expect(described_class.new(appointment, config).call).to eq('https://example.com/non-standard-db-cy.pdf')
+    end
+  end
+end

--- a/spec/support/pages/appointment_summary_page.rb
+++ b/spec/support/pages/appointment_summary_page.rb
@@ -51,7 +51,7 @@ class AppointmentSummaryPage < SitePrism::Page
                                                   three: '.t-number-of-previous-appointments-3'
   radio_buttons :requested_digital, true: '.t-requested-digital',
                                     false: '.t-requested-postal'
-  radio_buttons :welsh, true: '.t-requested-welsh', false: 't-requested-english'
+  radio_buttons :welsh, true: '.t-requested-welsh', false: '.t-requested-english'
 
   element :email, '.t-email'
   element :email_suggestion, '.t-email-suggestion'

--- a/spec/support/pages/appointment_summary_page.rb
+++ b/spec/support/pages/appointment_summary_page.rb
@@ -52,6 +52,7 @@ class AppointmentSummaryPage < SitePrism::Page
   radio_buttons :requested_digital, true: '.t-requested-digital',
                                     false: '.t-requested-postal'
   radio_buttons :welsh, true: '.t-requested-welsh', false: '.t-requested-english'
+  element :document_language, '.t-document-language'
 
   element :email, '.t-email'
   element :email_suggestion, '.t-email-suggestion'

--- a/spec/support/pages/appointment_summary_page.rb
+++ b/spec/support/pages/appointment_summary_page.rb
@@ -51,6 +51,7 @@ class AppointmentSummaryPage < SitePrism::Page
                                                   three: '.t-number-of-previous-appointments-3'
   radio_buttons :requested_digital, true: '.t-requested-digital',
                                     false: '.t-requested-postal'
+  radio_buttons :welsh, true: '.t-requested-welsh', false: 't-requested-english'
 
   element :email, '.t-email'
   element :email_suggestion, '.t-email-suggestion'


### PR DESCRIPTION
Permits Welsh summary documents in both forms - email and letter.

Handles TAP passing through the Welsh option when completing summary document records.